### PR TITLE
Eliminate Redundant fishVertexUniforms Update

### DIFF
--- a/aquarium-optimized/src/Aquarium.cpp
+++ b/aquarium-optimized/src/Aquarium.cpp
@@ -587,8 +587,7 @@ void Aquarium::drawFishes()
 
         const Fish &fishInfo = fishTable[i - MODELNAME::MODELSMALLFISHA];
         int numFish          = fishInfo.num;
-        model->updateFishCommonUniforms(fishInfo.fishLength, fishInfo.fishBendAmount,
-                                        fishInfo.fishWaveLength);
+
         model->preDraw();
 
         float fishBaseClock   = g.mclock * g_fishSpeed;

--- a/aquarium-optimized/src/FishModel.h
+++ b/aquarium-optimized/src/FishModel.h
@@ -18,9 +18,6 @@ class FishModel : public Model
   public:
     FishModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){};
 
-    virtual void updateFishCommonUniforms(float fishLength,
-                                          float fishBendAmount,
-                                          float fishWaveLength) = 0;
     virtual void updateFishPerUniforms(float x,
                                        float y,
                                        float z,

--- a/aquarium-optimized/src/dawn/FishModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/FishModelDawn.cpp
@@ -19,6 +19,11 @@ FishModelDawn::FishModelDawn(const Context *context,
 
     lightFactorUniforms.shininess      = 5.0f;
     lightFactorUniforms.specularFactor = 0.3f;
+
+    const Fish &fishInfo = fishTable[name - MODELNAME::MODELSMALLFISHA];
+    fishVertexUniforms.fishLength     = fishInfo.fishLength;
+    fishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
+    fishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
 }
 
 void FishModelDawn::init()
@@ -138,12 +143,12 @@ void FishModelDawn::init()
 
     contextDawn->setBufferData(lightFactorBuffer, 0, sizeof(LightFactorUniforms),
                                &lightFactorUniforms);
+    contextDawn->setBufferData(fishVertexBuffer, 0, sizeof(FishVertexUniforms),
+                               &fishVertexUniforms);
 }
 
 void FishModelDawn::preDraw() const
 {
-    contextDawn->setBufferData(fishVertexBuffer, 0, sizeof(FishVertexUniforms),
-                               &fishVertexUniforms);   
     contextDawn->setBufferData(viewBuffer, 0, sizeof(ViewUniforms), &viewUniformPer);
 }
 
@@ -174,15 +179,6 @@ void FishModelDawn::draw()
 void FishModelDawn::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
 {
     memcpy(&viewUniformPer, viewUniforms, sizeof(ViewUniforms));
-}
-
-void FishModelDawn::updateFishCommonUniforms(float fishLength,
-                                             float fishBendAmount,
-                                             float fishWaveLength)
-{
-    fishVertexUniforms.fishLength     = fishLength;
-    fishVertexUniforms.fishBendAmount = fishBendAmount;
-    fishVertexUniforms.fishWaveLength = fishWaveLength;
 }
 
 void FishModelDawn::updateFishPerUniforms(float x,

--- a/aquarium-optimized/src/dawn/FishModelDawn.h
+++ b/aquarium-optimized/src/dawn/FishModelDawn.h
@@ -31,9 +31,6 @@ class FishModelDawn : public FishModel
     void draw() override;
 
     void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
-    void updateFishCommonUniforms(float fishLength,
-                                  float fishBendAmount,
-                                  float fishWaveLength) override;
     void updateFishPerUniforms(float x,
                                float y,
                                float z,

--- a/aquarium-optimized/src/opengl/FishModelGL.cpp
+++ b/aquarium-optimized/src/opengl/FishModelGL.cpp
@@ -30,6 +30,11 @@ FishModelGL::FishModelGL(const ContextGL *contextGL,
 
     viewProjectionUniform.first = aquarium->viewUniforms.viewProjection;
     scaleUniform.first = 1;
+
+    const Fish &fishInfo              = fishTable[name - MODELNAME::MODELSMALLFISHA];
+    fishLengthUniform.first     = fishInfo.fishLength;
+    fishBendAmountUniform.first = fishInfo.fishBendAmount;
+    fishWaveLengthUniform.first = fishInfo.fishWaveLength;
 }
 
 void FishModelGL::init()
@@ -149,14 +154,7 @@ void FishModelGL::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
     contextGL->setUniform(worldPositionUniform.second, worldPositionUniform.first, GL_FLOAT_VEC3);
     contextGL->setUniform(nextPositionUniform.second, nextPositionUniform.first, GL_FLOAT_VEC3);
 }
-void FishModelGL::updateFishCommonUniforms(float fishLength,
-                                           float fishBendAmount,
-                                           float fishWaveLength)
-{
-    fishLengthUniform.first     = fishLength;
-    fishBendAmountUniform.first = fishBendAmount;
-    fishWaveLengthUniform.first = fishWaveLength;
-}
+
 void FishModelGL::updateFishPerUniforms(float x,
                                         float y,
                                         float z,

--- a/aquarium-optimized/src/opengl/FishModelGL.h
+++ b/aquarium-optimized/src/opengl/FishModelGL.h
@@ -21,9 +21,7 @@ class FishModelGL : public FishModel
     FishModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
     void preDraw() const override;
     void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
-    void updateFishCommonUniforms(float fishLength,
-                                  float fishBendAmount,
-                                  float fishWaveLength) override;
+
     void init() override;
     void draw() override;
 


### PR DESCRIPTION
fishVertexUniforms are common value for each type of fish,  and
should be set during initialization.

This commit fixes #7