### PR TITLE
Share lightFactorUniforms

### DIFF
--- a/aquarium-optimized/src/dawn/FishModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/FishModelDawn.cpp
@@ -17,14 +17,13 @@ FishModelDawn::FishModelDawn(const Context *context,
 {
     contextDawn = static_cast<const ContextDawn *>(context);
 
-    lightFactorUniforms.shininess      = 5.0f;
-    lightFactorUniforms.specularFactor = 0.3f;
-
     const Fish &fishInfo = fishTable[name - MODELNAME::MODELSMALLFISHA];
     fishVertexUniforms.fishLength     = fishInfo.fishLength;
     fishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
     fishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
 }
+
+FishModelDawn::LightFactorUniforms FishModelDawn::lightFactorUniforms = {5.0f, 0.3f};
 
 void FishModelDawn::init()
 {

--- a/aquarium-optimized/src/dawn/FishModelDawn.h
+++ b/aquarium-optimized/src/dawn/FishModelDawn.h
@@ -51,7 +51,7 @@ class FishModelDawn : public FishModel
     {
         float shininess;
         float specularFactor;
-    } lightFactorUniforms;
+    } static lightFactorUniforms;
 
     struct FishPer
     {

--- a/aquarium-optimized/src/dawn/GenericModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/GenericModelDawn.cpp
@@ -15,10 +15,9 @@ GenericModelDawn::GenericModelDawn(const Context *context,
     : GenericModel(type, name, blend), instance(0)
 {
     contextDawn = static_cast<const ContextDawn *>(context);
-
-    lightFactorUniforms.shininess      = 50.0f;
-    lightFactorUniforms.specularFactor = 1.0f;
 }
+
+GenericModelDawn::LightFactorUniforms GenericModelDawn::lightFactorUniforms = {50.0f, 1.0f};
 
 GenericModelDawn::~GenericModelDawn()
 {

--- a/aquarium-optimized/src/dawn/GenericModelDawn.h
+++ b/aquarium-optimized/src/dawn/GenericModelDawn.h
@@ -46,7 +46,7 @@ public:
     {
         float shininess;
         float specularFactor;
-    } lightFactorUniforms;
+    } static lightFactorUniforms;
 
     struct ViewUniformPer
     {

--- a/aquarium-optimized/src/dawn/InnerModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/InnerModelDawn.cpp
@@ -13,11 +13,9 @@ InnerModelDawn::InnerModelDawn(const Context* context, Aquarium* aquarium, MODEL
     : InnerModel(type, name, blend)
 {
     contextDawn = static_cast<const ContextDawn*>(context);
-
-    innerUniforms.eta = 1.0f;
-    innerUniforms.tankColorFudge = 0.796f;
-    innerUniforms.refractionFudge = 3.0f;
 }
+
+InnerModelDawn::InnerUniforms InnerModelDawn::innerUniforms = {1.0f, 0.796f, 3.0f};
 
 InnerModelDawn::~InnerModelDawn()
 {

--- a/aquarium-optimized/src/dawn/InnerModelDawn.h
+++ b/aquarium-optimized/src/dawn/InnerModelDawn.h
@@ -31,7 +31,7 @@ class InnerModelDawn : public InnerModel
         float tankColorFudge;
         float refractionFudge;
         float padding;
-    } innerUniforms;
+    } static innerUniforms;
 
     ViewUniforms viewUniformPer;
 

--- a/aquarium-optimized/src/dawn/OutsideModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/OutsideModelDawn.cpp
@@ -9,10 +9,9 @@ OutsideModelDawn::OutsideModelDawn(const Context* context, Aquarium* aquarium, M
     : OutsideModel(type, name, blend)
 {
     contextDawn = static_cast<const ContextDawn*>(context);
-
-    lightFactorUniforms.shininess = 50.0f;
-    lightFactorUniforms.specularFactor = 0.0f;
 }
+
+OutsideModelDawn::LightFactorUniforms OutsideModelDawn::lightFactorUniforms = {50.0f, 0.0f};
 
 OutsideModelDawn::~OutsideModelDawn()
 {

--- a/aquarium-optimized/src/dawn/OutsideModelDawn.h
+++ b/aquarium-optimized/src/dawn/OutsideModelDawn.h
@@ -45,7 +45,7 @@ public:
     {
         float shininess;
         float specularFactor;
-    } lightFactorUniforms;
+    } static lightFactorUniforms;
 
     ViewUniforms viewUniformPer;
 

--- a/aquarium-optimized/src/dawn/SeaweedModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/SeaweedModelDawn.cpp
@@ -12,10 +12,10 @@ SeaweedModelDawn::SeaweedModelDawn(const Context* context, Aquarium* aquarium, M
 {
     contextDawn = static_cast<const ContextDawn*>(context);
     mAquarium   = aquarium;
-
-    lightFactorUniforms.shininess = 50.0f;
-    lightFactorUniforms.specularFactor = 1.0f;
 }
+
+
+SeaweedModelDawn::LightFactorUniforms SeaweedModelDawn::lightFactorUniforms = {50.0f, 1.0f};
 
 SeaweedModelDawn::~SeaweedModelDawn()
 {

--- a/aquarium-optimized/src/dawn/SeaweedModelDawn.h
+++ b/aquarium-optimized/src/dawn/SeaweedModelDawn.h
@@ -43,7 +43,7 @@ class SeaweedModelDawn : public SeaweedModel
     {
         float shininess;
         float specularFactor;
-    } lightFactorUniforms;
+    } static lightFactorUniforms;
 
     struct SeaweedPer
     {


### PR DESCRIPTION
LightFactorUniforms can be shared among multiple instances. These separate
instances use the same data for lightFactorUniforms, so we should instead
share a buffer between all instances of the same model. For example, the
uniform is the same to Rock, Ship and Coral.

This commit fixes #5