### PR TITLE
Support basic support of building Aquarium on ANGLE with GN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,15 +24,18 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+.cipd/
+
 .gclient_entries
+third_party/angle
 third_party/dawn
 third_party/glfw
+third_party/glslang
 third_party/googletest
 third_party/rapidjson
 third_party/stb
 third_party/llvm-build
 
-build_overrides/
 buildtools/
 out/
 testing/

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,6 +6,7 @@
 
 declare_args() {
   enable_dawn = true
+  enable_angle = false
 }
 
 executable("aquarium") {
@@ -22,6 +23,7 @@ executable("aquarium") {
     "aquarium-optimized/src/FPSTimer.cpp",
     "aquarium-optimized/src/FPSTimer.h",
     "aquarium-optimized/src/GenericModel.h",
+    "aquarium-optimized/src/InnerModel.h",
     "aquarium-optimized/src/Main.cpp",
     "aquarium-optimized/src/Matrix.h",
     "aquarium-optimized/src/Model.cpp",
@@ -54,20 +56,41 @@ executable("aquarium") {
 
   deps = [
     "third_party:stb",
-    "third_party:glad",
   ]
 
   include_dirs = [
-    "third_party/dawn/src",
-    "third_party/glad/include",
     "third_party/rapidjson/include",
     "third_party/stb",
   ]
 
   defines = []
 
+  if (enable_angle) {
+    enable_dawn = false
+
+    defines += [ "EGL_EGL_PROTOTYPES" ]
+
+    include_dirs += [
+      "third_party/angle/include",
+      "third_party/angle/util",
+    ]
+
+    deps += [
+      "third_party/angle:libANGLE",
+      "third_party/angle:libGLESv2",
+      "third_party/angle:libEGL",
+      "third_party/angle:angle_util_static",
+    ]
+  } else {
+    deps += [ "third_party:glad" ]
+
+    include_dirs += [ "third_party/glad/include" ]
+  }
+
   if (enable_dawn) {
     defines += [ "ENABLE_DAWN_BACKEND" ]
+
+    include_dirs += [ "third_party/dawn/src" ]
 
     sources += [
       "aquarium-optimized/src/dawn/BufferDawn.cpp",
@@ -111,7 +134,8 @@ executable("aquarium") {
   }
 
   cflags_cc = [
-    "-Wno-string-conversion"
+    "-Wno-string-conversion",
+    "-Wno-unused-result",
   ]
 }
 
@@ -153,6 +177,7 @@ executable("aquarium-direct-map") {
   ]
   
   cflags_cc = [
-    "-Wno-string-conversion"
+    "-Wno-string-conversion",
+    "-Wno-unused-result",
   ]
 }

--- a/DEPS
+++ b/DEPS
@@ -9,22 +9,34 @@ vars = {
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
   'dawn_revision': '54e4d47db4910ebd1ffce0247b60d4e6f984774f',
+  'angle_root': 'third_party/angle',
+  'angle_revision': 'e6b23e45b380bee1a2dfda06e4728d24d4d4ad8b',
+  'glslang_revision': '0527c9db8148ce37442fa4a9c99a2a23ad50b0b7',
 }
 
 deps = {
   # Dependencies required to use GN/Clang in standalone
+  # This revision should be the same as the one in third_party/angle/DEPS
   'build': {
-    'url': '{chromium_git}/chromium/src/build@e439f6082423106f1fe2afa7e22f8fd4c00691df',
+    'url': '{chromium_git}/chromium/src/build@a660b0b9174e3a808f620222017566e8d1b2669b',
   },
+  # This revision should be the same as the one in third_party/angle/DEPS
   'buildtools': {
-    'url': '{chromium_git}/chromium/buildtools@24ebce4578745db15274e180da1938ebc1358243',
+    'url': '{chromium_git}/chromium/src/buildtools@459baaf66bee809f6eb288e0215cf524f4d2429a',
   },
+  # This revision should be the same as the one in third_party/angle/DEPS
   'tools/clang': {
-    'url': '{chromium_git}/chromium/src/tools/clang@1d879cee563167a2b18baffb096cf9e29f2f9376',
+    'url': '{chromium_git}/chromium/src/tools/clang@3114fbc11f9644c54dd0a4cdbfa867bac50ff983',
   },
+  # This revision should be the same as the one in third_party/angle/DEPS
   'testing': {
-    'url': '{chromium_git}/chromium/src/testing@b07830f6905ce9e33034ad14820bc0a58b6e9e41',
+    'url': '{chromium_git}/chromium/src/testing@083d633e752e7a57cbe62a468a06e51e28c49ee9',
   },
+  # This revision should be the same as the one in third_party/angle/DEPS
+  'third_party/glslang': {
+    'url': '{chromium_git}/external/github.com/KhronosGroup/glslang@{glslang_revision}',
+  },
+
   'third_party/googletest': {
     'url': '{chromium_git}/external/github.com/google/googletest@5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081',
   },
@@ -41,47 +53,12 @@ deps = {
   'third_party/dawn': {
     'url': '{dawn_git}/dawn.git@{dawn_revision}',
   },
+  'third_party/angle': {
+    'url': '{chromium_git}/angle/angle.git@{angle_revision}',
+  },
 }
 
 hooks = [
-  # Pull GN binaries using checked-in hashes.
-  {
-    'name': 'gn_win',
-    'pattern': '.',
-    'condition': 'host_os == "win"',
-    'action': [ 'download_from_google_storage',
-                '--no_resume',
-                '--platform=win32',
-                '--no_auth',
-                '--bucket', 'chromium-gn',
-                '-s', 'buildtools/win/gn.exe.sha1',
-    ],
-  },
-  {
-    'name': 'gn_mac',
-    'pattern': '.',
-    'condition': 'host_os == "mac"',
-    'action': [ 'download_from_google_storage',
-                '--no_resume',
-                '--platform=darwin',
-                '--no_auth',
-                '--bucket', 'chromium-gn',
-                '-s', 'buildtools/mac/gn.sha1',
-    ],
-  },
-  {
-    'name': 'gn_linux64',
-    'pattern': '.',
-    'condition': 'host_os == "linux"',
-    'action': [ 'download_from_google_storage',
-                '--no_resume',
-                '--platform=linux*',
-                '--no_auth',
-                '--bucket', 'chromium-gn',
-                '-s', 'buildtools/linux64/gn.sha1',
-    ],
-  },
-
   # Pull the compilers and system libraries for hermetic builds
   {
     'name': 'sysroot_x86',
@@ -103,6 +80,13 @@ hooks = [
     'pattern': '.',
     'condition': 'checkout_win',
     'action': ['python', 'build/vs_toolchain.py', 'update', '--force'],
+  },
+  {
+    # Update the Mac toolchain if necessary.
+    'name': 'mac_toolchain',
+    'pattern': '.',
+    'condition': 'checkout_mac',
+    'action': ['python', '{angle_root}/build/mac_toolchain.py'],
   },
   {
     # Note: On Win, this should run after win_toolchain, as it may use it.
@@ -136,4 +120,5 @@ recursedeps = [
   # buildtools provides clang_format, libc++, and libc++abi
   'buildtools',
   'third_party/dawn',
+  'third_party/angle',
 ]

--- a/aquarium-direct-map/src/Program.cpp
+++ b/aquarium-direct-map/src/Program.cpp
@@ -73,15 +73,11 @@ void Program::createProgramFromTags(const std::string &vId, const std::string &f
     FragmentShaderCode =
         std::regex_replace(FragmentShaderCode, std::regex(R"(// #fogCode)"), fogCode);
 
-#ifdef _WIN32
-    FragmentShaderCode = std::regex_replace(FragmentShaderCode, std::regex(R"(^.*?// #noReflection\n)"), "");
-    FragmentShaderCode = std::regex_replace(FragmentShaderCode, std::regex(R"(^.*?// #noNormalMap\n)"), "");
-    #else
     FragmentShaderCode =
         std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
     FragmentShaderCode =
         std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
-#endif
+
     program = LoadProgram(VertexShaderCode, FragmentShaderCode);
 }
 

--- a/aquarium-direct-map/src/Uniform.h
+++ b/aquarium-direct-map/src/Uniform.h
@@ -15,7 +15,7 @@
 class Uniform
 {
 public:
-  Uniform(){};
+  Uniform(){}
   Uniform(const std::string &name, GLenum type, int length, int size, GLint index);
 
   std::string getName() const { return name; }

--- a/aquarium-optimized/src/Buffer.h
+++ b/aquarium-optimized/src/Buffer.h
@@ -15,9 +15,9 @@ class Buffer
 {
   public:
     Buffer() {}
-    Buffer(int numComponents, int numElements, const std::vector<float> &buffer){};
-    Buffer(int numComponents, int numElements, const std::vector<short> &buffer){};
-    virtual ~Buffer(){};
+    Buffer(int numComponents, int numElements, const std::vector<float> &buffer){}
+    Buffer(int numComponents, int numElements, const std::vector<short> &buffer){}
+    virtual ~Buffer(){}
 };
 
 #endif

--- a/aquarium-optimized/src/Context.h
+++ b/aquarium-optimized/src/Context.h
@@ -25,9 +25,9 @@ struct Global;
 class Context
 {
   public:
-    Context(){};
+    Context(){}
     virtual bool createContext(std::string backend, bool enableMSAA) = 0;
-    virtual ~Context() {};
+    virtual ~Context() {}
     virtual Texture *createTexture(std::string name, std::string url)                      = 0;
     virtual Texture *createTexture(std::string name, const std::vector<std::string> &urls) = 0;
     virtual Buffer *createBuffer(int numComponents, std::vector<float> &buffer, bool isIndex) = 0;
@@ -43,8 +43,8 @@ class Context
 
     virtual void preFrame() = 0;
 
-    int getClientWidth() const { return mClientWidth; };
-    int getclientHeight() const { return mClientHeight; };
+    int getClientWidth() const { return mClientWidth; }
+    int getclientHeight() const { return mClientHeight; }
 
     virtual Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) = 0;
 

--- a/aquarium-optimized/src/FishModel.h
+++ b/aquarium-optimized/src/FishModel.h
@@ -16,7 +16,7 @@
 class FishModel : public Model
 {
   public:
-    FishModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){};
+    FishModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){}
 
     virtual void updateFishPerUniforms(float x,
                                        float y,

--- a/aquarium-optimized/src/GenericModel.h
+++ b/aquarium-optimized/src/GenericModel.h
@@ -14,7 +14,7 @@
 class GenericModel : public Model
 {
   public:
-    GenericModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){};
+    GenericModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){}
 };
 
 #endif

--- a/aquarium-optimized/src/InnerModel.h
+++ b/aquarium-optimized/src/InnerModel.h
@@ -14,7 +14,7 @@
 class InnerModel : public Model
 {
   public:
-    InnerModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){};
+    InnerModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){}
 };
 
 #endif // !INNERMODEL_H

--- a/aquarium-optimized/src/Model.h
+++ b/aquarium-optimized/src/Model.h
@@ -32,7 +32,7 @@ class Model
   public:
     Model();
     Model(MODELGROUP type, MODELNAME name, bool blend)
-        : mProgram(nullptr), mBlend(blend), mName(name) {};
+        : mProgram(nullptr), mBlend(blend), mName(name) {}
     virtual ~Model();
     virtual void preDraw() const     = 0;
     virtual void updatePerInstanceUniforms(ViewUniforms* viewUniforms) = 0;

--- a/aquarium-optimized/src/OutsideModel.h
+++ b/aquarium-optimized/src/OutsideModel.h
@@ -14,7 +14,7 @@
 class OutsideModel : public Model
 {
   public:
-    OutsideModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){};
+    OutsideModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){}
 };
 
 #endif

--- a/aquarium-optimized/src/Program.h
+++ b/aquarium-optimized/src/Program.h
@@ -16,12 +16,12 @@ enum UNIFORMNAME : short;
 class Program
 {
   public:
-    Program(){};
+    Program(){}
     Program(std::string vertexShader, std::string fragmentShader)
         : vId(vertexShader), fId(fragmentShader)
     {
     }
-    virtual ~Program(){};
+    virtual ~Program(){}
     virtual void setProgram();
 
   protected:

--- a/aquarium-optimized/src/SeaweedModel.h
+++ b/aquarium-optimized/src/SeaweedModel.h
@@ -14,7 +14,7 @@
 class SeaweedModel : public Model
 {
   public:
-    SeaweedModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){};
+    SeaweedModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){}
 
     virtual void updateSeaweedModelTime(float time) = 0;
 };

--- a/aquarium-optimized/src/Texture.h
+++ b/aquarium-optimized/src/Texture.h
@@ -15,7 +15,7 @@
 class Texture
 {
   public:
-    virtual ~Texture(){};
+    virtual ~Texture(){}
     Texture() {}
     Texture(std::string name, const std::vector<std::string> &urls, bool flip) : mUrls(urls), mFlip(flip), mName(name) {}
     Texture(std::string name, const std::string &url, bool flip);

--- a/aquarium-optimized/src/dawn/ProgramDawn.cpp
+++ b/aquarium-optimized/src/dawn/ProgramDawn.cpp
@@ -33,17 +33,10 @@ void ProgramDawn::loadProgram()
         std::istreambuf_iterator<char>());
     FragmentShaderStream.close();
 
-#ifdef _WIN32
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(^.*?// #noReflection\n)"), "");
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(^.*?// #noNormalMap\n)"), "");
-#else
     FragmentShaderCode =
         std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
     FragmentShaderCode =
         std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
-#endif
 
     vsModule = context->createShaderModule(dawn::ShaderStage::Vertex, VertexShaderCode);
     fsModule = context->createShaderModule(dawn::ShaderStage::Fragment, FragmentShaderCode);

--- a/aquarium-optimized/src/opengl/ProgramGL.cpp
+++ b/aquarium-optimized/src/opengl/ProgramGL.cpp
@@ -85,17 +85,10 @@ void ProgramGL::loadProgram()
     FragmentShaderCode =
         std::regex_replace(FragmentShaderCode, std::regex(R"(// #fogCode)"), fogCode);
 
-#ifdef _WIN32
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(^.*?// #noReflection\n)"), "");
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(^.*?// #noNormalMap\n)"), "");
-#else
     FragmentShaderCode =
         std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
     FragmentShaderCode =
         std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
-#endif
 
     bool status = context->compileProgram(mProgramId, VertexShaderCode, FragmentShaderCode);
     ASSERT(status);

--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2019 The WebGLNativePorts Project Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+
+angle_root = "//third_party/angle"
+
+angle_glslang_dir = "//third_party/angle/third_party/glslang/src"
+angle_googletest_dir = "//third_party/angle/third_party/googletest/src"
+angle_libjpeg_turbo_dir = "//third_party/angle_third_party/libjpeg_turbo"
+angle_jsoncpp_dir = "//third_party/angle/third_party/jsoncpp"
+angle_libpng_dir = "//third_party/angle/third_party/libpng"
+angle_spirv_tools_dir = "//third_party/angle/third_party/spirv_tools/src"

--- a/samples/BUILD.gn
+++ b/samples/BUILD.gn
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 #
 
-shaderc_glslang_dir = "//third_party/glslang"
-shaderc_spirv_tools_dir = "//third_party/dawn/third_party/SPIRV-Tools"
-shaderc_spirv_cross_dir = "//third_party/dawn/third_party/"
+group("all") {
+  testonly = true
+  deps = []
+}

--- a/src/tests/BUILD.gn
+++ b/src/tests/BUILD.gn
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 #
 
-shaderc_glslang_dir = "//third_party/glslang"
-shaderc_spirv_tools_dir = "//third_party/dawn/third_party/SPIRV-Tools"
-shaderc_spirv_cross_dir = "//third_party/dawn/third_party/"
+group("all") {
+  testonly = true
+  deps = []
+}


### PR DESCRIPTION
This patch adds basic support of building Aquarium on latest ANGLE with GN.

The support is not perfect and still needs several extra steps:
1. Aquarium ANGLE backend cannot be co-existed with Dawn or OpenGL backend now
  because of conflicts in GL headers.
  So you should add "enable_angle = true" when running 'gn args out/ANGLE', which
  means disabling the Dawn and OpenGL backend.
2. Set 'angle_root' to 'third_party/angle' in 'third_party/angle/gni/angle.gni'
3. In 'gn args out/ANGLE', ANGLE Vulkan backend has to be disabled because of
   conflicts on Vulkan libraries in Dawn
   - Add "angle_enable_vulkan = false" when running 'gn args out/ANGLE'

Here are known issues:
1. The screen unexpectedly blinks on Aquarium on ANGLE.
2. Aquarium on ANGLE fails to build on macOS and Linux.