### PR TITLE
Optimize viewUniforms update

### DIFF
--- a/aquarium-optimized/src/Aquarium.h
+++ b/aquarium-optimized/src/Aquarium.h
@@ -327,12 +327,12 @@ struct LightWorldPositionUniform
 {
     float lightWorldPos[3];
     float padding;
-};
-
-struct ViewUniforms
-{
     float viewProjection[16];
     float viewInverse[16];
+};
+
+struct WorldUniforms
+{
     float world[16];
     float worldInverseTranspose[16];
     float worldViewProjection[16];
@@ -363,7 +363,7 @@ class Aquarium
     void display();
 
     LightWorldPositionUniform lightWorldPositionUniform;
-    ViewUniforms viewUniforms;
+    WorldUniforms worldUniforms;
     LightUniforms lightUniforms;
     FogUniforms fogUniforms;
     Global g;

--- a/aquarium-optimized/src/Model.h
+++ b/aquarium-optimized/src/Model.h
@@ -25,7 +25,7 @@ class Buffer;
 
 enum MODELGROUP : short;
 enum MODELNAME : short;
-struct ViewUniforms;
+struct WorldUniforms;
 
 class Model
 {
@@ -35,7 +35,7 @@ class Model
         : mProgram(nullptr), mBlend(blend), mName(name) {}
     virtual ~Model();
     virtual void preDraw() const     = 0;
-    virtual void updatePerInstanceUniforms(ViewUniforms* viewUniforms) = 0;
+    virtual void updatePerInstanceUniforms(WorldUniforms* worldUniforms) = 0;
     virtual void draw() = 0;
 
     void setProgram(Program *program);

--- a/aquarium-optimized/src/dawn/FishModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/FishModelDawn.cpp
@@ -112,9 +112,6 @@ void FishModelDawn::init()
     lightFactorBuffer = contextDawn->createBufferFromData(
         &lightFactorUniforms, sizeof(LightFactorUniforms),
         dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
-    viewBuffer = contextDawn->createBufferFromData(
-        &viewUniformPer, sizeof(ViewUniforms),
-        dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
 
     // Fish models includes small, medium and big. Some of them contains reflection and skybox
     // texture, but some doesn't.
@@ -140,11 +137,6 @@ void FishModelDawn::init()
                                {4, normalTexture->getTextureView()}});
     }
 
-    bindGroupPer =
-        contextDawn->makeBindGroup(groupLayoutPer, {
-                                                       {0, viewBuffer, 0, sizeof(ViewUniforms)},
-                                                   });
-
     contextDawn->setBufferData(lightFactorBuffer, 0, sizeof(LightFactorUniforms),
                                &lightFactorUniforms);
     contextDawn->setBufferData(fishVertexBuffer, 0, sizeof(FishVertexUniforms),
@@ -153,7 +145,6 @@ void FishModelDawn::init()
 
 void FishModelDawn::preDraw() const
 {
-    contextDawn->setBufferData(viewBuffer, 0, sizeof(ViewUniforms), &viewUniformPer);
 }
 
 void FishModelDawn::draw()
@@ -167,7 +158,6 @@ void FishModelDawn::draw()
     pass.SetBindGroup(0, contextDawn->bindGroupGeneral, 0, nullptr);
     pass.SetBindGroup(1, contextDawn->bindGroupWorld, 0, nullptr);
     pass.SetBindGroup(2, bindGroupModel, 0, nullptr);
-    pass.SetBindGroup(3, bindGroupPer, 0, nullptr);
     pass.SetVertexBuffers(0, 1, &positionBuffer->getBuffer(), vertexBufferOffsets);
     pass.SetVertexBuffers(1, 1, &normalBuffer->getBuffer(), vertexBufferOffsets);
     pass.SetVertexBuffers(2, 1, &texCoordBuffer->getBuffer(), vertexBufferOffsets);
@@ -180,9 +170,8 @@ void FishModelDawn::draw()
     instance = 0;
 }
 
-void FishModelDawn::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
+void FishModelDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
 {
-    memcpy(&viewUniformPer, viewUniforms, sizeof(ViewUniforms));
 }
 
 void FishModelDawn::updateFishPerUniforms(float x,
@@ -217,6 +206,5 @@ FishModelDawn::~FishModelDawn()
     bindGroupPer      = nullptr;
     fishVertexBuffer  = nullptr;
     lightFactorBuffer = nullptr;
-    viewBuffer        = nullptr;
     fishPersBuffer    = nullptr;
 }

--- a/aquarium-optimized/src/dawn/FishModelDawn.h
+++ b/aquarium-optimized/src/dawn/FishModelDawn.h
@@ -30,7 +30,7 @@ class FishModelDawn : public FishModel
     void preDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
     void updateFishPerUniforms(float x,
                                float y,
                                float z,
@@ -61,8 +61,6 @@ class FishModelDawn : public FishModel
         float time;
     }fishPers[100000];
 
-    ViewUniforms viewUniformPer;
-
     TextureDawn *diffuseTexture;
     TextureDawn *normalTexture;
     TextureDawn *reflectionTexture;
@@ -89,7 +87,6 @@ class FishModelDawn : public FishModel
 
     dawn::Buffer fishVertexBuffer;
     dawn::Buffer lightFactorBuffer;
-    dawn::Buffer viewBuffer;
 
     dawn::Buffer fishPersBuffer;
 

--- a/aquarium-optimized/src/dawn/GenericModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/GenericModelDawn.cpp
@@ -134,7 +134,7 @@ void GenericModelDawn::init()
         &lightFactorUniforms, sizeof(lightFactorUniforms),
         dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
     viewBuffer = contextDawn->createBufferFromData(
-        &viewUniformPer, sizeof(ViewUniformPer),
+        &worldUniformPer, sizeof(worldUniformPer),
         dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
 
     // Generic models use reflection, normal or diffuse shaders, of which grouplayouts are
@@ -173,7 +173,7 @@ void GenericModelDawn::init()
 
     bindGroupPer =
         contextDawn->makeBindGroup(groupLayoutPer, {
-                                                       {0, viewBuffer, 0, sizeof(ViewUniformPer)},
+                                                       {0, viewBuffer, 0, sizeof(WorldUniformPer)},
                                                    });
 
     contextDawn->setBufferData(lightFactorBuffer, 0, sizeof(LightFactorUniforms),
@@ -182,7 +182,7 @@ void GenericModelDawn::init()
 
 void GenericModelDawn::preDraw() const
 {
-    contextDawn->setBufferData(viewBuffer, 0, sizeof(ViewUniformPer), &viewUniformPer);
+    contextDawn->setBufferData(viewBuffer, 0, sizeof(WorldUniformPer), &worldUniformPer);
 }
 
 void GenericModelDawn::draw()
@@ -209,9 +209,9 @@ void GenericModelDawn::draw()
     instance = 0;
 }
 
-void GenericModelDawn::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
+void GenericModelDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
 {
-    viewUniformPer.viewuniforms[instance] = *viewUniforms;
-    //memcpy(viewUniformPer.viewuniforms + sizeof(ViewUniforms) * instance, viewUniforms, sizeof(ViewUniforms));
+    worldUniformPer.WorldUniforms[instance] = *worldUniforms;
+
     instance++;
 }

--- a/aquarium-optimized/src/dawn/GenericModelDawn.h
+++ b/aquarium-optimized/src/dawn/GenericModelDawn.h
@@ -18,16 +18,19 @@
 
 class GenericModelDawn : public GenericModel
 {
-public:
-    GenericModelDawn(const Context* context, Aquarium* aquarium, MODELGROUP type, MODELNAME name, bool blend);
+  public:
+    GenericModelDawn(const Context *context,
+                     Aquarium *aquarium,
+                     MODELGROUP type,
+                     MODELNAME name,
+                     bool blend);
     ~GenericModelDawn();
 
     void init() override;
     void preDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
-
+    void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
 
     TextureDawn *diffuseTexture;
     TextureDawn *normalTexture;
@@ -48,11 +51,11 @@ public:
         float specularFactor;
     } lightFactorUniforms;
 
-    struct ViewUniformPer
+    struct WorldUniformPer
     {
-        ViewUniforms viewuniforms[20];
+        WorldUniforms WorldUniforms[20];
     };
-    ViewUniformPer viewUniformPer;
+    WorldUniformPer worldUniformPer;
 
 private:
   dawn::InputStateDescriptor inputState;

--- a/aquarium-optimized/src/dawn/InnerModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/InnerModelDawn.cpp
@@ -89,7 +89,7 @@ void InnerModelDawn::init()
 
     innerBuffer = contextDawn->createBufferFromData(&innerUniforms, sizeof(innerUniforms), dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
     viewBuffer = contextDawn->createBufferFromData(
-        &viewUniformPer, sizeof(ViewUniforms),
+        &worldUniformPer, sizeof(WorldUniforms),
         dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
 
     bindGroupModel = contextDawn->makeBindGroup(groupLayoutModel, {
@@ -104,7 +104,7 @@ void InnerModelDawn::init()
 
     bindGroupPer =
         contextDawn->makeBindGroup(groupLayoutPer, {
-                                                       {0, viewBuffer, 0, sizeof(ViewUniforms)},
+                                                       {0, viewBuffer, 0, sizeof(WorldUniforms)},
                                                    });
 
     contextDawn->setBufferData(innerBuffer, 0, sizeof(InnerUniforms), &innerUniforms);
@@ -133,9 +133,9 @@ void InnerModelDawn::draw()
     pass.DrawIndexed(indicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void InnerModelDawn::updatePerInstanceUniforms(ViewUniforms* viewUniforms)
+void InnerModelDawn::updatePerInstanceUniforms(WorldUniforms* worldUniforms)
 {
-    std::memcpy(&viewUniformPer, viewUniforms, sizeof(ViewUniforms));
+    std::memcpy(&worldUniformPer, worldUniforms, sizeof(WorldUniforms));
 
-    contextDawn->setBufferData(viewBuffer, 0, sizeof(ViewUniforms), &viewUniformPer);
+    contextDawn->setBufferData(viewBuffer, 0, sizeof(WorldUniforms), &worldUniformPer);
 }

--- a/aquarium-optimized/src/dawn/InnerModelDawn.h
+++ b/aquarium-optimized/src/dawn/InnerModelDawn.h
@@ -23,7 +23,7 @@ class InnerModelDawn : public InnerModel
     void init() override;
     void preDraw() const override;
     void draw() override;
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
 
     struct InnerUniforms
     {
@@ -33,7 +33,7 @@ class InnerModelDawn : public InnerModel
         float padding;
     } innerUniforms;
 
-    ViewUniforms viewUniformPer;
+    WorldUniforms worldUniformPer;
 
     TextureDawn *diffuseTexture;
     TextureDawn *normalTexture;

--- a/aquarium-optimized/src/dawn/OutsideModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/OutsideModelDawn.cpp
@@ -83,7 +83,7 @@ void OutsideModelDawn::init()
         &lightFactorUniforms, sizeof(lightFactorUniforms),
         dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
     viewBuffer = contextDawn->createBufferFromData(
-        &viewUniformPer, sizeof(ViewUniforms),
+        &worldUniformPer, sizeof(WorldUniforms),
         dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
 
     bindGroupModel = contextDawn->makeBindGroup(groupLayoutModel, {
@@ -93,7 +93,7 @@ void OutsideModelDawn::init()
     });
 
     bindGroupPer = contextDawn->makeBindGroup(groupLayoutPer, {
-        {0, viewBuffer, 0, sizeof(ViewUniforms)},
+        {0, viewBuffer, 0, sizeof(WorldUniforms)},
     });
 
     contextDawn->setBufferData(lightFactorBuffer, 0, sizeof(LightFactorUniforms), &lightFactorUniforms);
@@ -125,8 +125,8 @@ void OutsideModelDawn::draw()
     pass.DrawIndexed(indicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void OutsideModelDawn::updatePerInstanceUniforms(ViewUniforms *viewUniforms) {
-    memcpy(&viewUniformPer, viewUniforms, sizeof(ViewUniforms));
+void OutsideModelDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms) {
+    memcpy(&worldUniformPer, worldUniforms, sizeof(WorldUniforms));
 
-    contextDawn->setBufferData(viewBuffer, 0, sizeof(ViewUniforms), &viewUniformPer);
+    contextDawn->setBufferData(viewBuffer, 0, sizeof(WorldUniforms), &worldUniformPer);
 }

--- a/aquarium-optimized/src/dawn/OutsideModelDawn.h
+++ b/aquarium-optimized/src/dawn/OutsideModelDawn.h
@@ -26,7 +26,7 @@ public:
     void preDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
 
     TextureDawn *diffuseTexture;
     TextureDawn *normalTexture;
@@ -47,7 +47,7 @@ public:
         float specularFactor;
     } lightFactorUniforms;
 
-    ViewUniforms viewUniformPer;
+    WorldUniforms worldUniformPer;
 
 private:
   dawn::InputStateDescriptor inputState;

--- a/aquarium-optimized/src/dawn/SeaweedModelDawn.cpp
+++ b/aquarium-optimized/src/dawn/SeaweedModelDawn.cpp
@@ -84,7 +84,7 @@ void SeaweedModelDawn::init()
         dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
     timeBuffer = contextDawn->createBufferFromData(&seaweedPer, sizeof(seaweedPer), dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
     viewBuffer = contextDawn->createBufferFromData(
-        &viewUniformPer, sizeof(ViewUniformPer),
+        &worldUniformPer, sizeof(WorldUniformPer),
         dawn::BufferUsageBit::TransferDst | dawn::BufferUsageBit::Uniform);
 
     bindGroupModel = contextDawn->makeBindGroup(groupLayoutModel, {
@@ -94,7 +94,7 @@ void SeaweedModelDawn::init()
     });
 
     bindGroupPer = contextDawn->makeBindGroup(groupLayoutPer, {
-        { 0, viewBuffer, 0, sizeof(ViewUniformPer)},
+        { 0, viewBuffer, 0, sizeof(WorldUniformPer)},
         { 1, timeBuffer, 0, sizeof(SeaweedPer) },
     });
 
@@ -103,7 +103,7 @@ void SeaweedModelDawn::init()
 
 void SeaweedModelDawn::preDraw() const
 {
-    contextDawn->setBufferData(viewBuffer, 0, sizeof(ViewUniformPer), &viewUniformPer);
+    contextDawn->setBufferData(viewBuffer, 0, sizeof(WorldUniformPer), &worldUniformPer);
     contextDawn->setBufferData(timeBuffer, 0, sizeof(SeaweedPer), &seaweedPer);
 }
 
@@ -125,9 +125,9 @@ void SeaweedModelDawn::draw()
     instance = 0;
 }
 
-void SeaweedModelDawn::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
+void SeaweedModelDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
 {
-    viewUniformPer.viewuniforms[instance] = *viewUniforms;
+    worldUniformPer.worldUniforms[instance] = *worldUniforms;
     seaweedPer.time[instance]             = mAquarium->g.mclock + instance;
 
     instance++;

--- a/aquarium-optimized/src/dawn/SeaweedModelDawn.h
+++ b/aquarium-optimized/src/dawn/SeaweedModelDawn.h
@@ -24,7 +24,7 @@ class SeaweedModelDawn : public SeaweedModel
     void preDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
 
 
     TextureDawn *diffuseTexture;
@@ -50,11 +50,11 @@ class SeaweedModelDawn : public SeaweedModel
         float time[20];
     } seaweedPer;
 
-    struct ViewUniformPer
+    struct WorldUniformPer
     {
-        ViewUniforms viewuniforms[20];
+        WorldUniforms worldUniforms[20];
     };
-    ViewUniformPer viewUniformPer;
+    WorldUniformPer worldUniformPer;
 
   private:
     dawn::InputStateDescriptor inputState;

--- a/aquarium-optimized/src/opengl/FishModelGL.cpp
+++ b/aquarium-optimized/src/opengl/FishModelGL.cpp
@@ -16,7 +16,7 @@ FishModelGL::FishModelGL(const ContextGL *contextGL,
                          bool blend)
     : FishModel(type, name, blend), contextGL(contextGL)
 {
-    viewInverseUniform.first = aquarium->viewUniforms.viewInverse;
+    viewInverseUniform.first = aquarium->lightWorldPositionUniform.viewInverse;
     lightWorldPosUniform.first = aquarium->lightWorldPositionUniform.lightWorldPos;
     lightColorUniform.first = aquarium->lightUniforms.lightColor;
     specularUniform.first = aquarium->lightUniforms.specular;
@@ -28,7 +28,7 @@ FishModelGL::FishModelGL(const ContextGL *contextGL,
     fogOffsetUniform.first = g_fogOffset;
     fogColorUniform.first = aquarium->fogUniforms.fogColor;
 
-    viewProjectionUniform.first = aquarium->viewUniforms.viewProjection;
+    viewProjectionUniform.first = aquarium->lightWorldPositionUniform.viewProjection;
     scaleUniform.first = 1;
 
     const Fish &fishInfo              = fishTable[name - MODELNAME::MODELSMALLFISHA];
@@ -147,7 +147,7 @@ void FishModelGL::preDraw() const
     }
 }
 
-void FishModelGL::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
+void FishModelGL::updatePerInstanceUniforms(WorldUniforms *WorldUniforms)
 {
     contextGL->setUniform(scaleUniform.second, &scaleUniform.first, GL_FLOAT);
     contextGL->setUniform(timeUniform.second, &timeUniform.first, GL_FLOAT);

--- a/aquarium-optimized/src/opengl/FishModelGL.h
+++ b/aquarium-optimized/src/opengl/FishModelGL.h
@@ -20,7 +20,7 @@ class FishModelGL : public FishModel
   public:
     FishModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
     void preDraw() const override;
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
 
     void init() override;
     void draw() override;

--- a/aquarium-optimized/src/opengl/GenericModelGL.cpp
+++ b/aquarium-optimized/src/opengl/GenericModelGL.cpp
@@ -14,16 +14,16 @@ GenericModelGL::GenericModelGL(const ContextGL *context,
                                bool blend)
     : GenericModel(type, name, blend), contextGL(context)
 {
-    viewInverseUniform.first = aquarium->viewUniforms.viewInverse;
+    viewInverseUniform.first = aquarium->lightWorldPositionUniform.viewInverse;
     lightWorldPosUniform.first = aquarium->lightWorldPositionUniform.lightWorldPos;
     lightColorUniform.first = aquarium->lightUniforms.lightColor;
     specularUniform.first = aquarium->lightUniforms.specular;
     shininessUniform.first = 50.0f;
     specularFactorUniform.first = 1.0f;
     ambientUniform.first = aquarium->lightUniforms.ambient;
-    worldUniform.first = aquarium->viewUniforms.world;
-    worldViewProjectionUniform.first = aquarium->viewUniforms.worldViewProjection;
-    worldInverseTransposeUniform.first = aquarium->viewUniforms.worldInverseTranspose;
+    worldUniform.first = aquarium->worldUniforms.world;
+    worldViewProjectionUniform.first = aquarium->worldUniforms.worldViewProjection;
+    worldInverseTransposeUniform.first = aquarium->worldUniforms.worldInverseTranspose;
     fogPowerUniform.first = g_fogPower;
     fogMultUniform.first = g_fogMult;
     fogOffsetUniform.first = g_fogOffset;
@@ -123,7 +123,7 @@ void GenericModelGL::preDraw() const
     }
 }
 
-void GenericModelGL::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
+void GenericModelGL::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
 {
     contextGL->setUniform(worldUniform.second, worldUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(worldViewProjectionUniform.second, worldViewProjectionUniform.first,

--- a/aquarium-optimized/src/opengl/GenericModelGL.h
+++ b/aquarium-optimized/src/opengl/GenericModelGL.h
@@ -22,7 +22,7 @@ class GenericModelGL : public GenericModel
                    MODELNAME name,
                    bool blend);
     void preDraw() const override;
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
     void init() override;
     void draw() override;
 

--- a/aquarium-optimized/src/opengl/InnerModelGL.cpp
+++ b/aquarium-optimized/src/opengl/InnerModelGL.cpp
@@ -14,12 +14,12 @@ InnerModelGL::InnerModelGL(const ContextGL *context,
                            bool blend)
     : InnerModel(type, name, blend), contextGL(context)
 {
-    viewInverseUniform.first = aquarium->viewUniforms.viewInverse;
+    viewInverseUniform.first   = aquarium->lightWorldPositionUniform.viewInverse;
     lightWorldPosUniform.first = aquarium->lightWorldPositionUniform.lightWorldPos;
 
-    worldUniform.first = aquarium->viewUniforms.world;
-    worldViewProjectionUniform.first = aquarium->viewUniforms.worldViewProjection;
-    worldInverseTransposeUniform.first = aquarium->viewUniforms.worldInverseTranspose;
+    worldUniform.first                 = aquarium->worldUniforms.world;
+    worldViewProjectionUniform.first   = aquarium->worldUniforms.worldViewProjection;
+    worldInverseTransposeUniform.first = aquarium->worldUniforms.worldInverseTranspose;
 
     etaUniform.first = 1.0f;
     tankColorFudgeUniform.first = 0.796f;
@@ -118,7 +118,7 @@ void InnerModelGL::preDraw() const
     contextGL->setTexture(skyboxTexture.first, skyboxTexture.second, 3);
 }
 
-void InnerModelGL::updatePerInstanceUniforms(ViewUniforms* viewUniforms)
+void InnerModelGL::updatePerInstanceUniforms(WorldUniforms* worldUniforms)
 {
     contextGL->setUniform(worldUniform.second, worldUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(worldViewProjectionUniform.second, worldViewProjectionUniform.first,

--- a/aquarium-optimized/src/opengl/InnerModelGL.h
+++ b/aquarium-optimized/src/opengl/InnerModelGL.h
@@ -18,13 +18,13 @@ class InnerModelGL : public InnerModel
   public:
     InnerModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
     void preDraw() const override;
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
     void init() override;
     void draw() override;
 
     std::pair<float *, int> worldViewProjectionUniform;
     std::pair<float *, int> worldUniform;
-    // std::pair<float*, int> worldInverseUniform;
+    std::pair<float*, int> worldInverseUniform;
     std::pair<float *, int> worldInverseTransposeUniform;
 
     std::pair<float *, int> viewInverseUniform;

--- a/aquarium-optimized/src/opengl/OutsideModelGL.cpp
+++ b/aquarium-optimized/src/opengl/OutsideModelGL.cpp
@@ -14,16 +14,16 @@ OutsideModelGL::OutsideModelGL(const ContextGL *context,
                                bool blend)
     : OutsideModel(type, name, blend), contextGL(context)
 {
-    viewInverseUniform.first = aquarium->viewUniforms.viewInverse;
+    viewInverseUniform.first           = aquarium->lightWorldPositionUniform.viewInverse;
     lightWorldPosUniform.first = aquarium->lightWorldPositionUniform.lightWorldPos;
     lightColorUniform.first = aquarium->lightUniforms.lightColor;
     specularUniform.first = aquarium->lightUniforms.specular;
     shininessUniform.first = 50.0f;
     specularFactorUniform.first = 0.0f;
     ambientUniform.first = aquarium->lightUniforms.ambient;
-    worldUniform.first = aquarium->viewUniforms.world;
-    worldViewProjectionUniform.first = aquarium->viewUniforms.worldViewProjection;
-    worldInverseTransposeUniform.first = aquarium->viewUniforms.worldInverseTranspose;
+    worldUniform.first = aquarium->worldUniforms.world;
+    worldViewProjectionUniform.first = aquarium->worldUniforms.worldViewProjection;
+    worldInverseTransposeUniform.first = aquarium->worldUniforms.worldInverseTranspose;
     fogPowerUniform.first = 0;
     fogMultUniform.first = 0;
     fogOffsetUniform.first = 0;
@@ -103,7 +103,7 @@ void OutsideModelGL::preDraw() const
     contextGL->setTexture(diffuseTexture.first, diffuseTexture.second, 0);
 }
 
-void OutsideModelGL::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
+void OutsideModelGL::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
 {
     contextGL->setUniform(worldUniform.second, worldUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(worldViewProjectionUniform.second, worldViewProjectionUniform.first,

--- a/aquarium-optimized/src/opengl/OutsideModelGL.h
+++ b/aquarium-optimized/src/opengl/OutsideModelGL.h
@@ -22,7 +22,7 @@ class OutsideModelGL : public OutsideModel
                    MODELNAME name,
                    bool blend);
     void preDraw() const override;
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
     void init() override;
     void draw() override;
 

--- a/aquarium-optimized/src/opengl/SeaweedModelGL.cpp
+++ b/aquarium-optimized/src/opengl/SeaweedModelGL.cpp
@@ -14,19 +14,19 @@ SeaweedModelGL::SeaweedModelGL(const ContextGL *context,
                                bool blend)
     : SeaweedModel(type, name, blend), contextGL(context)
 {
-    viewInverseUniform.first = aquarium->viewUniforms.viewInverse;
+    viewInverseUniform.first    = aquarium->lightWorldPositionUniform.viewInverse;
     lightWorldPosUniform.first = aquarium->lightWorldPositionUniform.lightWorldPos;
     lightColorUniform.first = aquarium->lightUniforms.lightColor;
     specularUniform.first = aquarium->lightUniforms.specular;
     shininessUniform.first = 50.0f;
     specularFactorUniform.first = 1.0f;
     ambientUniform.first = aquarium->lightUniforms.ambient;
-    worldUniform.first = aquarium->viewUniforms.world;
+    worldUniform.first = aquarium->worldUniforms.world;
     fogPowerUniform.first = g_fogPower;
     fogMultUniform.first = g_fogMult;
     fogOffsetUniform.first = g_fogOffset;
     fogColorUniform.first = aquarium->fogUniforms.fogColor;
-    viewProjectionUniform.first = aquarium->viewUniforms.viewProjection;
+    viewProjectionUniform.first = aquarium->lightWorldPositionUniform.viewProjection;
 }
 
 void SeaweedModelGL::init()
@@ -103,7 +103,7 @@ void SeaweedModelGL::preDraw() const
     contextGL->setTexture(diffuseTexture.first, diffuseTexture.second, 0);
 }
 
-void SeaweedModelGL::updatePerInstanceUniforms(ViewUniforms *viewUniforms)
+void SeaweedModelGL::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
 {
     contextGL->setUniform(worldUniform.second, worldUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(timeUniform.second, &timeUniform.first, GL_FLOAT);

--- a/aquarium-optimized/src/opengl/SeaweedModelGL.h
+++ b/aquarium-optimized/src/opengl/SeaweedModelGL.h
@@ -22,7 +22,7 @@ class SeaweedModelGL : public SeaweedModel
                    MODELNAME name,
                    bool blend);
     void preDraw() const override;
-    void updatePerInstanceUniforms(ViewUniforms *viewUniforms) override;
+    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
     void init() override;
     void draw() override;
 

--- a/shaders/dawn/diffuseVertexShader
+++ b/shaders/dawn/diffuseVertexShader
@@ -2,19 +2,19 @@
 
 layout(std140, set = 1, binding = 0) uniform LightWorldPositionUniform {
      vec3 lightWorldPos;
+     mat4 viewProjection;
+     mat4 viewInverse;
 } lightWorldPositionUniform;
 
-struct ViewUniforms
+struct WorldUniform
 {
-    mat4 viewProjection;
-    mat4 viewInverse;
     mat4 world;
     mat4 worldInverseTranspose;
     mat4 worldViewProjection;
 };
 
 layout(std140, set = 3, binding = 0) uniform WorldUniforms {
-	ViewUniforms views[20];
+	WorldUniform worlds[20];
 } worldUniforms;
 
 layout(location = 0) in vec4 position;
@@ -28,10 +28,10 @@ layout(location = 3) out vec3 v_surfaceToLight;
 layout(location = 4) out vec3 v_surfaceToView;
 void main() {
   v_texCoord = texCoord;
-  v_position = (worldUniforms.views[gl_InstanceIndex].worldViewProjection * position);
-  v_normal = (worldUniforms.views[gl_InstanceIndex].worldInverseTranspose * vec4(normal, 0)).xyz;
-  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (worldUniforms.views[gl_InstanceIndex].world * position).xyz;
-  v_surfaceToView = (worldUniforms.views[gl_InstanceIndex].viewInverse[3] - (worldUniforms.views[gl_InstanceIndex].world * position)).xyz;
+  v_position = (worldUniforms.worlds[gl_InstanceIndex].worldViewProjection * position);
+  v_normal = (worldUniforms.worlds[gl_InstanceIndex].worldInverseTranspose * vec4(normal, 0)).xyz;
+  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (worldUniforms.worlds[gl_InstanceIndex].world * position).xyz;
+  v_surfaceToView = (lightWorldPositionUniform.viewInverse[3] - (worldUniforms.worlds[gl_InstanceIndex].world * position)).xyz;
   v_position.y = -v_position.y;
   gl_Position = v_position;
 }

--- a/shaders/dawn/fishVertexShader
+++ b/shaders/dawn/fishVertexShader
@@ -2,15 +2,9 @@
 
 layout(std140, set = 1, binding = 0) uniform LightWorldPositionUniform {
     vec3 lightWorldPos;
-} lightWorldPositionUniform;
-
-layout(std140, set = 3, binding = 0) uniform ViewUniforms {
 	mat4 viewProjection;
 	mat4 viewInverse;
-    mat4 world;
-	mat4 worldInverseTranspose;
-    mat4 worldViewProjection;
-} viewUniforms;
+} lightWorldPositionUniform;
 
 layout(std140, set = 2, binding = 0) uniform FishVertexUniforms {
     float fishLength;
@@ -49,7 +43,7 @@ void main() {
     vec4(0, 0, scale, 0),
     vec4(0, 0, 0, 1));
   mat4 world = orientMat * scaleMat;
-  mat4 worldViewProjection = viewUniforms.viewProjection * world;
+  mat4 worldViewProjection = lightWorldPositionUniform.viewProjection * world;
   mat4 worldInverseTranspose = world;
 
   v_texCoord = texCoord;
@@ -66,7 +60,7 @@ void main() {
        vec4(offset, 0, 0, 0)));
   v_normal = (worldInverseTranspose * vec4(normal, 0)).xyz;
   v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (world * position).xyz;
-  v_surfaceToView = (viewUniforms.viewInverse[3] - (world * position)).xyz;
+  v_surfaceToView = (lightWorldPositionUniform.viewInverse[3] - (world * position)).xyz;
   v_binormal = (worldInverseTranspose * vec4(binormal, 0)).xyz;  // #normalMap
   v_tangent = (worldInverseTranspose * vec4(tangent, 0)).xyz;  // #normalMap
   v_position.y = -v_position.y;

--- a/shaders/dawn/innerRefractionMapVertexShader
+++ b/shaders/dawn/innerRefractionMapVertexShader
@@ -2,16 +2,15 @@
 
 layout(std140, set = 1, binding = 0) uniform LightWorldPositionUniform {
     vec3 lightWorldPos;
-	float padding;
+    mat4 viewProjection;
+    mat4 viewInverse;
 } lightWorldPositionUniform;
 
-layout(std140, set = 3, binding = 0) uniform ViewUniforms {
-	mat4 viewProjection;
-	mat4 viewInverse;
+layout(std140, set = 3, binding = 0) uniform WorldUniforms {
     mat4 world;
 	mat4 worldInverseTranspose;
     mat4 worldViewProjection;
-} viewUniforms;
+} worldUniforms;
 
 layout(location = 0) in vec4 position;
 layout(location = 1) in vec3 normal;
@@ -27,12 +26,12 @@ layout(location = 5) out vec3 v_surfaceToLight;
 layout(location = 6) out vec3 v_surfaceToView;
 void main() {
   v_texCoord = texCoord;
-  v_position = (viewUniforms.worldViewProjection * position);
-  v_normal = (viewUniforms.worldInverseTranspose * vec4(normal, 0)).xyz;
-  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (viewUniforms.world * position).xyz;
-  v_surfaceToView = (viewUniforms.viewInverse[3] - (viewUniforms.world * position)).xyz;
-  v_binormal = (viewUniforms.worldInverseTranspose * vec4(binormal, 0)).xyz;  // #normalMap
-  v_tangent = (viewUniforms.worldInverseTranspose * vec4(tangent, 0)).xyz;  // #normalMap
+  v_position = (worldUniforms.worldViewProjection * position);
+  v_normal = (worldUniforms.worldInverseTranspose * vec4(normal, 0)).xyz;
+  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (worldUniforms.world * position).xyz;
+  v_surfaceToView = (lightWorldPositionUniform.viewInverse[3] - (worldUniforms.world * position)).xyz;
+  v_binormal = (worldUniforms.worldInverseTranspose * vec4(binormal, 0)).xyz;  // #normalMap
+  v_tangent = (worldUniforms.worldInverseTranspose * vec4(tangent, 0)).xyz;  // #normalMap
   v_position.y = -v_position.y;
   gl_Position = v_position;
 }

--- a/shaders/dawn/normalMapVertexShader
+++ b/shaders/dawn/normalMapVertexShader
@@ -2,19 +2,19 @@
 
 layout(std140, set = 1, binding = 0) uniform LightWorldPositionUniform {
     vec3 lightWorldPos;
-} lightWorldPositionUniform;
-
-struct ViewUniforms
-{
     mat4 viewProjection;
     mat4 viewInverse;
+} lightWorldPositionUniform;
+
+struct WorldUniform
+{
     mat4 world;
     mat4 worldInverseTranspose;
     mat4 worldViewProjection;
 };
 
 layout(std140, set = 3, binding = 0) uniform WorldUniforms {
-    ViewUniforms views[20];
+    WorldUniform worlds[20];
 } worldUniforms;
 
 layout(location = 0) in vec4 position;
@@ -31,12 +31,12 @@ layout(location = 5) out vec3 v_surfaceToLight;
 layout(location = 6) out vec3 v_surfaceToView;
 void main() {
   v_texCoord = texCoord;
-  v_position = (worldUniforms.views[gl_InstanceIndex].worldViewProjection * position);
-  v_normal = (worldUniforms.views[gl_InstanceIndex].worldInverseTranspose * vec4(normal, 0)).xyz;
-  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (worldUniforms.views[gl_InstanceIndex].world * position).xyz;
-  v_surfaceToView = (worldUniforms.views[gl_InstanceIndex].viewInverse[3] - (worldUniforms.views[gl_InstanceIndex].world * position)).xyz;
-  v_binormal = (worldUniforms.views[gl_InstanceIndex].worldInverseTranspose * vec4(binormal, 0)).xyz;  // #normalMap
-  v_tangent = (worldUniforms.views[gl_InstanceIndex].worldInverseTranspose * vec4(tangent, 0)).xyz;  // #normalMap
+  v_position = (worldUniforms.worlds[gl_InstanceIndex].worldViewProjection * position);
+  v_normal = (worldUniforms.worlds[gl_InstanceIndex].worldInverseTranspose * vec4(normal, 0)).xyz;
+  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (worldUniforms.worlds[gl_InstanceIndex].world * position).xyz;
+  v_surfaceToView = (lightWorldPositionUniform.viewInverse[3] - (worldUniforms.worlds[gl_InstanceIndex].world * position)).xyz;
+  v_binormal = (worldUniforms.worlds[gl_InstanceIndex].worldInverseTranspose * vec4(binormal, 0)).xyz;  // #normalMap
+  v_tangent = (worldUniforms.worlds[gl_InstanceIndex].worldInverseTranspose * vec4(tangent, 0)).xyz;  // #normalMap
   v_position.y = -v_position.y;
   gl_Position = v_position;
 }

--- a/shaders/dawn/reflectionMapVertexShader
+++ b/shaders/dawn/reflectionMapVertexShader
@@ -2,15 +2,15 @@
 
 layout(std140, set = 1, binding = 0) uniform LightWorldPositionUniform {
     vec3 lightWorldPos;
+    mat4 viewProjection;
+    mat4 viewInverse;
 } lightWorldPositionUniform;
 
-layout(std140, set = 3, binding = 0) uniform ViewUniforms {
-	mat4 viewProjection;
-	mat4 viewInverse;
+layout(std140, set = 3, binding = 0) uniform WorldUniforms {
     mat4 world;
 	mat4 worldInverseTranspose;
     mat4 worldViewProjection;
-} viewUniforms;
+} worldUniforms;
 
 layout(location = 0) in vec4 position;
 layout(location = 1) in vec3 normal;
@@ -26,12 +26,12 @@ layout(location = 5) out vec3 v_surfaceToLight;
 layout(location = 6) out vec3 v_surfaceToView;
 void main() {
   v_texCoord = texCoord;
-  v_position = (viewUniforms.worldViewProjection * position);
-  v_normal = (viewUniforms.worldInverseTranspose * vec4(normal, 0)).xyz;
-  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (viewUniforms.world * position).xyz;
-  v_surfaceToView = (viewUniforms.viewInverse[3] - (viewUniforms.world * position)).xyz;
-  v_binormal = (viewUniforms.worldInverseTranspose * vec4(binormal, 0)).xyz;
-  v_tangent = (viewUniforms.worldInverseTranspose * vec4(tangent, 0)).xyz;
+  v_position = (worldUniforms.worldViewProjection * position);
+  v_normal = (worldUniforms.worldInverseTranspose * vec4(normal, 0)).xyz;
+  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (worldUniforms.world * position).xyz;
+  v_surfaceToView = (lightWorldPositionUniform.viewInverse[3] - (worldUniforms.world * position)).xyz;
+  v_binormal = (worldUniforms.worldInverseTranspose * vec4(binormal, 0)).xyz;
+  v_tangent = (worldUniforms.worldInverseTranspose * vec4(tangent, 0)).xyz;
   v_position.y = -v_position.y;
   gl_Position = v_position;
 }

--- a/shaders/dawn/seaweedVertexShader
+++ b/shaders/dawn/seaweedVertexShader
@@ -1,20 +1,20 @@
 #version 450
 
 layout(std140, set = 1, binding = 0) uniform LightWorldPositionUniform {
-     vec3 lightWorldPos;
-} lightWorldPositionUniform;
-
-struct ViewUniforms
-{
+    vec3 lightWorldPos;
     mat4 viewProjection;
     mat4 viewInverse;
+} lightWorldPositionUniform;
+
+struct WorldUniform
+{
     mat4 world;
     mat4 worldInverseTranspose;
     mat4 worldViewProjection;
 };
 
 layout(std140, set = 3, binding = 0) uniform WorldUniforms {
-    ViewUniforms views[20];
+    WorldUniform worlds[20];
 } worldUniforms;
 
 layout(std140,set = 3, binding = 1) uniform SeaweedPer {
@@ -30,7 +30,7 @@ layout(location = 2) out vec3 v_normal;
 layout(location = 3) out vec3 v_surfaceToLight;
 layout(location = 4) out vec3 v_surfaceToView;
 void main() {
-  vec3 toCamera = normalize(worldUniforms.views[gl_InstanceIndex].viewInverse[3].xyz - worldUniforms.views[gl_InstanceIndex].world[3].xyz);
+  vec3 toCamera = normalize(lightWorldPositionUniform.viewInverse[3].xyz - worldUniforms.worlds[gl_InstanceIndex].world[3].xyz);
   vec3 yAxis = vec3(0, 1, 0);
   vec3 xAxis = cross(yAxis, toCamera);
   vec3 zAxis = cross(xAxis, yAxis);
@@ -39,7 +39,7 @@ void main() {
       vec4(xAxis, 0),
       vec4(yAxis, 0),
       vec4(xAxis, 0),
-      worldUniforms.views[gl_InstanceIndex].world[3]);
+      worldUniforms.worlds[gl_InstanceIndex].world[3]);
 
   v_texCoord = texCoord;
   v_position = position + vec4(
@@ -47,10 +47,10 @@ void main() {
       -4,  // TODO(gman): remove this hack
       0,
       0);
-  v_position = (worldUniforms.views[gl_InstanceIndex].viewProjection * newWorld) * v_position;
+  v_position = (lightWorldPositionUniform.viewProjection * newWorld) * v_position;
   v_normal = (newWorld * vec4(normal, 0)).xyz;
-  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (worldUniforms.views[gl_InstanceIndex].world * position).xyz;
-  v_surfaceToView = (worldUniforms.views[gl_InstanceIndex].viewInverse[3] - (worldUniforms.views[gl_InstanceIndex].world * position)).xyz;
+  v_surfaceToLight = lightWorldPositionUniform.lightWorldPos - (worldUniforms.worlds[gl_InstanceIndex].world * position).xyz;
+  v_surfaceToView = (lightWorldPositionUniform.viewInverse[3] - (worldUniforms.worlds[gl_InstanceIndex].world * position)).xyz;
   v_position.y = -v_position.y;
   gl_Position = v_position;
 }


### PR DESCRIPTION
viewProjection and viewInverse can be shared by all of the models
and should only update once per frame.  world, worldInverseTranspose
and worldViewProjection are different to every instance of the models.
So the above uniforms should be classified to different uniform buffers.
