### PR TITLE
Remove hardcoded values for FishPers

### DIFF
--- a/aquarium-optimized/src/Aquarium.cpp
+++ b/aquarium-optimized/src/Aquarium.cpp
@@ -83,6 +83,8 @@ Aquarium::Aquarium()
     lightUniforms.ambient[1] = g_ambientGreen;
     lightUniforms.ambient[2] = g_ambientBlue;
     lightUniforms.ambient[3] = 0.0f;
+
+    memset(fishCount, 0, 5);
 }
 
 Aquarium::~Aquarium()
@@ -174,9 +176,9 @@ void Aquarium::init(int argc, char **argv)
 
     setupModelEnumMap();
 
-    loadReource();
-
     calculateFishCount();
+
+    loadReource();
 }
 
 void Aquarium::display()
@@ -457,7 +459,7 @@ void Aquarium::calculateFishCount()
                 }
             }
             numLeft      = numLeft - numfloat;
-            fishInfo.num = numfloat;
+            fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA] = numfloat;
         }
         }
 }
@@ -589,7 +591,7 @@ void Aquarium::drawFishes()
         FishModel *model = static_cast<FishModel *>(mAquariumModels[i]);
 
         const Fish &fishInfo = fishTable[i - MODELNAME::MODELSMALLFISHA];
-        int numFish          = fishInfo.num;
+        int numFish          = fishCount[i - MODELNAME::MODELSMALLFISHA];
 
         if (mBackendpath == "opengl" || mBackendpath == "angle")
         {
@@ -630,8 +632,7 @@ void Aquarium::drawFishes()
                 sin(xClock - 0.04f) * xRadius, sin(yClock - 0.01f) * yRadius + fishHeight,
                 cos(zClock - 0.04f) * zRadius, scale,
                 fmod((g.mclock + ii * g_tailOffsetMult) * fishTailSpeed * speed,
-                     static_cast<float>(M_PI) * 2));
-
+                     static_cast<float>(M_PI) * 2), ii);
             if (mBackendpath=="opengl" || mBackendpath == "angle")
             {
                 model->updatePerInstanceUniforms(&worldUniforms);

--- a/aquarium-optimized/src/Aquarium.h
+++ b/aquarium-optimized/src/Aquarium.h
@@ -190,37 +190,48 @@ struct Fish
     float laserRot;
     float laserOff[3];
     float laserScale[3];
-    int num;
 };
 
-static Fish fishTable[] = {{"SmallFishA", MODELNAME::MODELSMALLFISHA, FISHENUM::SMALL, 1.0f, 1.5f,
-                            30.0f, 25.0f, 10.0f, 0.0f, 16.0f, 10.0f, 1.0f, 2.0f},
-                           {"MediumFishA", MODELNAME::MODELMEDIUMFISHA, FISHENUM::MEDIUM, 1.0f,
-                            2.0f, 10.0f, 20.0f, 1.0f, 0.0f, 16.0f, 10.0f, -2.0f, 2.0f},
-                           {"MediumFishB", MODELNAME::MODELMEDIUMFISHB, FISHENUM::MEDIUM, 0.5f,
-                            4.0f, 10.0f, 20.0f, 3.0f, -8.0f, 5.0f, 10.0f, -2.0f, 2.0f},
-                           {"BigFishA",    MODELNAME::MODELBIGFISHA,
-                            FISHENUM::BIG, 0.5f,
-                            0.5f,          50.0f,
-                            3.0f,          1.5f,
-                            0.0f,          16.0f,
-                            10.0f,         -1.0f,
-                            0.5f,          true,
-                            0.04f,         {0.0f,
-                            0.1f,          9.0f},
-                            {0.3f,          0.3f,
-                            1000.0f}},
-                           {"BigFishB",    MODELNAME::MODELBIGFISHB,
-                            FISHENUM::BIG, 0.5f,
-                            0.5f,          45.0f,
-                            3.0f,          1.0f,
-                            0.0f,          16.0f,
-                            10.0f,         -0.7f,
-                            0.3f,          true,
-                            0.04f,         {0.0f,
-                            -0.3f,         9.0f},
-                            {0.3f,          0.3f,
-                            1000.0f}} };
+const Fish fishTable[] = {{"SmallFishA", MODELNAME::MODELSMALLFISHA, FISHENUM::SMALL, 1.0f, 1.5f,
+                           30.0f, 25.0f, 10.0f, 0.0f, 16.0f, 10.0f, 1.0f, 2.0f},
+                          {"MediumFishA", MODELNAME::MODELMEDIUMFISHA, FISHENUM::MEDIUM, 1.0f, 2.0f,
+                           10.0f, 20.0f, 1.0f, 0.0f, 16.0f, 10.0f, -2.0f, 2.0f},
+                          {"MediumFishB", MODELNAME::MODELMEDIUMFISHB, FISHENUM::MEDIUM, 0.5f, 4.0f,
+                           10.0f, 20.0f, 3.0f, -8.0f, 5.0f, 10.0f, -2.0f, 2.0f},
+                          {"BigFishA",
+                           MODELNAME::MODELBIGFISHA,
+                           FISHENUM::BIG,
+                           0.5f,
+                           0.5f,
+                           50.0f,
+                           3.0f,
+                           1.5f,
+                           0.0f,
+                           16.0f,
+                           10.0f,
+                           -1.0f,
+                           0.5f,
+                           true,
+                           0.04f,
+                           {0.0f, 0.1f, 9.0f},
+                           {0.3f, 0.3f, 1000.0f}},
+                          {"BigFishB",
+                           MODELNAME::MODELBIGFISHB,
+                           FISHENUM::BIG,
+                           0.5f,
+                           0.5f,
+                           45.0f,
+                           3.0f,
+                           1.0f,
+                           0.0f,
+                           16.0f,
+                           10.0f,
+                           -0.7f,
+                           0.3f,
+                           true,
+                           0.04f,
+                           {0.0f, -0.3f, 9.0f},
+                           {0.3f, 0.3f, 1000.0f}}};
 
 constexpr float g_tailOffsetMult      = 1.0f;
 constexpr float g_endOfDome           = static_cast<float>(M_PI / 8);
@@ -367,6 +378,7 @@ class Aquarium
     LightUniforms lightUniforms;
     FogUniforms fogUniforms;
     Global g;
+    int fishCount[5];
 
   private:
     void render();

--- a/aquarium-optimized/src/FishModel.h
+++ b/aquarium-optimized/src/FishModel.h
@@ -25,7 +25,8 @@ class FishModel : public Model
                                        float nextY,
                                        float nextZ,
                                        float scale,
-                                       float time)              = 0;
+                                       float time,
+                                       int index) = 0;
 };
 
 #endif

--- a/aquarium-optimized/src/dawn/FishModelDawn.h
+++ b/aquarium-optimized/src/dawn/FishModelDawn.h
@@ -38,7 +38,8 @@ class FishModelDawn : public FishModel
                                float nextY,
                                float nextZ,
                                float scale,
-                               float time) override;
+                               float time,
+                               int index) override;
 
     struct FishVertexUniforms
     {
@@ -59,7 +60,8 @@ class FishModelDawn : public FishModel
         float scale;
         float nextPosition[3];
         float time;
-    }fishPers[100000];
+    };
+    FishPer *fishPers;
 
     TextureDawn *diffuseTexture;
     TextureDawn *normalTexture;

--- a/aquarium-optimized/src/opengl/FishModelGL.cpp
+++ b/aquarium-optimized/src/opengl/FishModelGL.cpp
@@ -162,7 +162,8 @@ void FishModelGL::updateFishPerUniforms(float x,
                                         float nextY,
                                         float nextZ,
                                         float scale,
-                                        float time)
+                                        float time,
+                                        int index)
 {
     worldPositionUniform.first[0] = x;
     worldPositionUniform.first[1] = y;

--- a/aquarium-optimized/src/opengl/FishModelGL.h
+++ b/aquarium-optimized/src/opengl/FishModelGL.h
@@ -32,7 +32,8 @@ class FishModelGL : public FishModel
                                float nextY,
                                float nextZ,
                                float scale,
-                               float time) override;
+                               float time,
+                               int index) override;
 
     std::pair<float *, int> viewInverseUniform;
     std::pair<float *, int> lightWorldPosUniform;


### PR DESCRIPTION
FishPers buffer size should be dynamically created on the number
of fish. And instance of fish should also be initialized.

This commit fixes #3 