### PR TITLE
Enable dynamic buffer offset on Dawn backend

### DIFF
--- a/aquarium-optimized/README.md
+++ b/aquarium-optimized/README.md
@@ -128,6 +128,8 @@ build aquarium by vs
 # running angle dynamic backend is on todo list. Currently go through angle path by option 'opengl' if angle is linked into the project
 # MSAA is disabled by default. To Enable MSAA of OpenGL backend, "--enable-msaa", 4 samples.
 # MSAA of angle is not supported now.
+# “--disable-dynamic-buffer-offset” ：The path is to test individual draw by creating many binding groups on dawn backend.
+# By default, dynamic buffer offset is enabled. The arg is only supported on dawn backend.
 
 # run on Windows
 run it in Visual Studio

--- a/aquarium-optimized/src/Aquarium.cpp
+++ b/aquarium-optimized/src/Aquarium.cpp
@@ -55,7 +55,8 @@ Aquarium::Aquarium()
       mPath(""),
       factory(nullptr),
       enableMSAA(false),
-      allowInstancedDraws(false)
+      allowInstancedDraws(false),
+      enableDynamicBufferOffset(true)
 {
     g.then     = 0.0f;
     g.mclock   = 0.0f;
@@ -198,7 +199,21 @@ bool Aquarium::init(int argc, char **argv)
                                         mBackendType == BACKENDTYPE::BACKENDTYPELAST))
             {
                 std::cerr << "Instanced draw path isn't implemented for " + mBackendFullpath +
-                                 " backend.";
+                                 " backend."
+                          << std::endl;
+                return false;
+            }
+        }
+        else if (cmd == "--disable-dynamic-buffer-offset")
+        {
+            enableDynamicBufferOffset = false;
+            if (allowInstancedDraws || (mBackendType != BACKENDTYPE::BACKENDTYPEDAWND3D12 &&
+                                        mBackendType != BACKENDTYPE::BACKENDTYPEDAWNVULKAN &&
+                                        mBackendType != BACKENDTYPE::BACKENDTYPEDAWNMETAL))
+            {
+                std::cerr << "Non dynamic buffer offset individual draw is only implemented for "
+                             "dawn backend."
+                          << std::endl;
                 return false;
             }
         }

--- a/aquarium-optimized/src/Aquarium.h
+++ b/aquarium-optimized/src/Aquarium.h
@@ -5,7 +5,6 @@
 //
 // Aquarium.h: Define global variables, enums, constant variables and Class Aquarium.
 
-
 #ifndef AQUARIUM_H
 #define AQUARIUM_H
 
@@ -415,6 +414,7 @@ class Aquarium
     bool init(int argc, char **argv);
     void display();
     Texture *getSkybox() { return mTextureMap["skybox"]; }
+    bool getEnableDynamicBufferOffset() { return enableDynamicBufferOffset; }
 
     LightWorldPositionUniform lightWorldPositionUniform;
     WorldUniforms worldUniforms;
@@ -439,6 +439,7 @@ class Aquarium
     ContextFactory *factory;
     bool enableMSAA;
     bool allowInstancedDraws;
+    bool enableDynamicBufferOffset;
     std::vector<std::string> skyUrls;
 
     void updateUrls();

--- a/aquarium-optimized/src/dawn/FishModelDawn.h
+++ b/aquarium-optimized/src/dawn/FishModelDawn.h
@@ -97,6 +97,8 @@ class FishModelDawn : public FishModel
 
     ProgramDawn *programDawn;
     const ContextDawn *contextDawn;
+
+    bool enableDynamicBufferOffset;
 };
 
 #endif


### PR DESCRIPTION
Since dynamic buffer offset is implemented in dawn. We will replace
creating many binding groups by this feature. Only one binding group
will be created and buffer offset is dynamically set to draw every fish.