### PR TITLE
Enable MSAA on native D3D12 backend

### DIFF
--- a/aquarium-optimized/src/d3d12/ContextD3D12.h
+++ b/aquarium-optimized/src/d3d12/ContextD3D12.h
@@ -117,6 +117,9 @@ class ContextD3D12 : public Context
     void GetHardwareAdapter(IDXGIFactory2 *pFactory, IDXGIAdapter1 **ppAdapter);
     void WaitForPreviousFrame();
     void createDepthStencilView();
+    void stateTransition(ComPtr<ID3D12Resource> &resource,
+                         D3D12_RESOURCE_STATES preState,
+                         D3D12_RESOURCE_STATES transferState) const;
 
     GLFWwindow *mWindow;
     ComPtr<ID3D12Device> m_device;
@@ -157,6 +160,11 @@ class ContextD3D12 : public Context
     D3D12_CONSTANT_BUFFER_VIEW_DESC fogView;
     ComPtr<ID3D12Resource> fogBuffer;
     ComPtr<ID3D12Resource> fogUploadBuffer;
+
+    ComPtr<ID3D12Resource> mSceneRenderTargetTexture;
+    D3D12_RENDER_TARGET_VIEW_DESC mSceneRenderTargetView;
+
+    bool mEnableMSAA;
 };
 
 #endif

--- a/aquarium-optimized/src/d3d12/TextureD3D12.cpp
+++ b/aquarium-optimized/src/d3d12/TextureD3D12.cpp
@@ -35,7 +35,6 @@ void TextureD3D12::loadTexture()
 
     if (mTextureViewDimension == D3D12_SRV_DIMENSION_TEXTURECUBE)
     {
-
         D3D12_RESOURCE_DESC textureDesc = {};
         textureDesc.MipLevels           = 1;
         textureDesc.Format              = mFormat;

--- a/aquarium-optimized/src/dawn/ContextDawn.cpp
+++ b/aquarium-optimized/src/dawn/ContextDawn.cpp
@@ -116,10 +116,7 @@ bool ContextDawn::createContext(BACKENDTYPE backend, bool enableMSAA)
     mClientWidth            = mode->width;
     mClientHeight           = mode->height;
     // If we show the window bar on the top, max width and height will be 1916 x 1053.
-    // Use a window mode currently
-    // mClientWidth  = 1024;
-    // mClientHeight = 768;
-    // Minus the height of title bar
+    // Minus the height of title bar, or dawn vulkan backend cannot work.
     mClientHeight -= 20;
 
     mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium", NULL, NULL);


### PR DESCRIPTION
This commit adds 4xMSAA feature on Aquarium native D3D12 backend.
Create an MSAA texture as render target, then call function
ResolveSubresource to resolve the texture to swapchain back buffer.