### PR TITLE
Fix splash screen issue in angle backend

### DIFF
--- a/aquarium-optimized/src/Aquarium.cpp
+++ b/aquarium-optimized/src/Aquarium.cpp
@@ -229,12 +229,13 @@ bool Aquarium::init(int argc, char **argv)
         context      = factory->createContext(mBackendType);
     }
 
-    if (mBackendType == BACKENDTYPE::BACKENDTYPEOPENGL)
+    if (mBackendType == BACKENDTYPE::BACKENDTYPEOPENGL || mBackendType == BACKENDTYPE::BACKENDTYPEANGLE)
     {
 #ifndef EGL_EGL_PROTOTYPES
         mShaderVersion = "450";
 #else
         mShaderVersion = "100";
+        mBackendFullpath = "opengl";
 #endif
     }
 

--- a/aquarium-optimized/src/opengl/ContextGL.cpp
+++ b/aquarium-optimized/src/opengl/ContextGL.cpp
@@ -45,7 +45,7 @@ bool ContextGL::createContext(BACKENDTYPE backend, bool enableMSAA)
 #ifdef GL_GLEXT_PROTOTYPES
     // TODO(yizhou) : Enable msaa in angle. Render into a multisample Texture and then blit to a
     // none multisample texture.
-
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 #else
     if (enableMSAA)
     {
@@ -82,8 +82,6 @@ bool ContextGL::createContext(BACKENDTYPE backend, bool enableMSAA)
     glfwWindowHint(GLFW_DECORATED, GL_FALSE);
     glfwMakeContextCurrent(mWindow);
 #else
-    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-
     std::vector<EGLAttrib> display_attribs;
 
     display_attribs.push_back(EGL_PLATFORM_ANGLE_TYPE_ANGLE);
@@ -391,7 +389,6 @@ void ContextGL::DoFlush()
 {
 #ifdef GL_GLEXT_PROTOTYPES
     eglSwapBuffers(mDisplay, mSurface);
-    glfwSwapBuffers(mWindow);
 #else
     glfwSwapBuffers(mWindow);
 #endif


### PR DESCRIPTION
When init context for angle, GLFW_NO_API hint should be set before
creating the window. By default, glfw will create an opengl context.
Angle has eglSwapBuffers api, so glfwSwapBuffers isn't required to
swap the buffer again.