### PR TITLE
Manage optional GPU features with a global bitset

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -30,6 +30,8 @@ executable("aquarium") {
     "src/aquarium-optimized/Model.cpp",
     "src/aquarium-optimized/Model.h",
     "src/aquarium-optimized/Program.h",
+    "src/aquarium-optimized/ResourceHelper.h",
+    "src/aquarium-optimized/ResourceHelper.cpp",
     "src/aquarium-optimized/SeaweedModel.h",
     "src/aquarium-optimized/Texture.cpp",
     "src/aquarium-optimized/Texture.h",

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ aquarium.exe --num-fish 10000 --backend angle
 ./aquarium  --num-fish 10000 --backend opengl
 ./aquarium.exe --num-fish 10000 --backend dawn_metal
 
-# "--allow-instanced-draws" : specifies rendering fishes by instanced draw. By default fishes
+# "--enable-instanced-draws" : specifies rendering fishes by instanced draw. By default fishes
 # are rendered by individual draw. Instanced rendering is only supported on dawn and d3d12 backend now.
 
-aquarium.exe --num-fish 10000 --backend dawn_d3d12 --allow-instanced-draws
-aquarium.exe --num-fish 10000 --backend dawn_vulkan --allow-instanced-draws
-aquarium.exe --num-fish 10000 --backend d3d12 --allow-instanced-draws
+aquarium.exe --num-fish 10000 --backend dawn_d3d12 --enable-instanced-draws
+aquarium.exe --num-fish 10000 --backend dawn_vulkan --enable-instanced-draws
+aquarium.exe --num-fish 10000 --backend d3d12 --enable-instanced-draws
 
 # MSAA is disabled by default. To Enable MSAA, "--enable-msaa", 4 samples.
 # MSAA of angle is not supported now.
@@ -153,6 +153,12 @@ aquarium.exe --num-fish 10000 --backend opengl --enable-msaa
 
 aquarium.exe --num-fish 10000 --backend dawn_d3d12 --disable-dynamic-buffer-offset
 aquarium.exe --num-fish 10000 --backend dawn_vulkan --disable-dynamic-buffer-offset
+
+# "--integrated-gpu", "--discreted-gpu": Specifies which gpu to render the application. The two args are exclusive.
+# This is an optional arg. By default, a default adapter will be created.
+# The option is only supported on dawn and d3d12 backend.
+aquarium.exe --num-fish 10000 --backend dawn_d3d12 --integrated-gpu
+aquarium.exe --num-fish 10000 --backend dawn_vulkan --discreted-gpu
 
 # aquarium-direct-map only has OpenGL backend
 # Enable MSAA

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -9,21 +9,11 @@
 // other models. Calculate fish count for each type of fish.
 // Update uniforms for each frame.
 
-#include <fstream>
 #include <iostream>
-#include <sstream>
-
-#ifdef _WIN32
-#include <direct.h>
-#include "Windows.h"
-#elif __APPLE__
-#include <mach-o/dyld.h>
-#else
-#include <unistd.h>
-#endif
 
 #include <algorithm>
 #include <cmath>
+#include <fstream>
 
 #include "Aquarium.h"
 #include "ContextFactory.h"
@@ -40,9 +30,6 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
-static const char *shaderFolder   = "shaders";
-static const char *resourceFolder = "assets";
-
 Aquarium::Aquarium()
     : mModelEnumMap(),
       mTextureMap(),
@@ -51,13 +38,8 @@ Aquarium::Aquarium()
       context(nullptr),
       fpsTimer(),
       mFishCount(1),
-      mBackendType(BACKENDTYPE::BACKENDTYPEOPENGL),
-      mShaderVersion(""),
-      mPath(""),
-      factory(nullptr),
-      enableMSAA(false),
-      allowInstancedDraws(false),
-      enableDynamicBufferOffset(true)
+      mBackendType(BACKENDTYPE::BACKENDTYPELAST),
+      factory(nullptr)
 {
     g.then     = 0.0f;
     g.mclock   = 0.0f;
@@ -166,7 +148,7 @@ bool Aquarium::init(int argc, char **argv)
     // "--backend" {backend}: create different backends. currently opengl is supported.
     // "--num-fish" {numfish}: imply rendering fish count.
     // "--enable-msaa": enable 4 times MSAA.
-    // "--allow-instanced-draws": use instanced draw. By default, it's individual draw.
+    // "--enable-instanced-draws": use instanced draw. By default, it's individual draw.
     char *pNext;
     for (int i = 1; i < argc; ++i)
     {
@@ -177,6 +159,34 @@ bool Aquarium::init(int argc, char **argv)
 
             return false;
         }
+        if (cmd == "--backend")
+        {
+            std::string backend = argv[i++ + 1];
+            mBackendType        = getBackendType(backend);
+
+            if (mBackendType == BACKENDTYPE::BACKENDTYPELAST)
+            {
+                std::cout << "Can not create " << backend << " backend" << std::endl;
+                return false;
+            }
+
+            context = factory->createContext(mBackendType);
+        }
+        else
+        {
+        }
+    }
+
+    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> availableToggleBitset =
+        context->getAvailableToggleBitset();
+    if (availableToggleBitset.test(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL)))
+    {
+        toggleBitset.set(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
+    }
+
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string cmd(argv[i]);
         if (cmd == "--num-fish")
         {
             mFishCount = strtol(argv[i++ + 1], &pNext, 10);
@@ -186,92 +196,84 @@ bool Aquarium::init(int argc, char **argv)
                 return false;
             }
         }
-        else if (cmd == "--backend")
-        {
-            mBackendFullpath = argv[i++ + 1];
-            mBackendType = getBackendType(mBackendFullpath);
-            if (mBackendType == BACKENDTYPE::BACKENDTYPELAST)
-            {
-                std::cout << "Can not create " << mBackendFullpath << " backend" << std::endl;
-                return false;
-            }
-
-            if (mBackendFullpath.find("dawn") != std::string::npos)
-            {
-                mBackendFullpath = "dawn";
-            }
-
-            context = factory->createContext(mBackendType);
-        }
         else if (cmd == "--enable-msaa")
         {
-            enableMSAA = true;
-            if (enableMSAA && mBackendType == BACKENDTYPE::BACKENDTYPEANGLE)
+            if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEMSAAx4)))
             {
-                std::cerr << "MSAA isn't implemented for angle backend." << std::endl;
+                std::cerr << "MSAA isn't implemented for the backend." << std::endl;
                 return false;
             }
+            toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEMSAAx4));
         }
-        else if (cmd == "--allow-instanced-draws")
+        else if (cmd == "--enable-instanced-draws")
         {
-            allowInstancedDraws = true;
-            if (allowInstancedDraws && (mBackendType == BACKENDTYPE::BACKENDTYPEANGLE ||
-                                        mBackendType == BACKENDTYPE::BACKENDTYPEOPENGL ||
-                                        mBackendType == BACKENDTYPE::BACKENDTYPEFIRST ||
-                                        mBackendType == BACKENDTYPE::BACKENDTYPELAST))
+            if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
             {
-                std::cerr << "Instanced draw path isn't implemented for " + mBackendFullpath +
-                                 " backend."
-                          << std::endl;
+                std::cerr << "Instanced draw path isn't implemented for the backend." << std::endl;
                 return false;
             }
+            toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
         }
         else if (cmd == "--disable-dynamic-buffer-offset")
         {
-            enableDynamicBufferOffset = false;
-            if (allowInstancedDraws || (mBackendType != BACKENDTYPE::BACKENDTYPEDAWND3D12 &&
-                                        mBackendType != BACKENDTYPE::BACKENDTYPEDAWNVULKAN &&
-                                        mBackendType != BACKENDTYPE::BACKENDTYPEDAWNMETAL))
+            if (!availableToggleBitset.test(
+                    static_cast<size_t>(TOGGLE::DISABLEDYNAMICBUFFEROFFSET)))
             {
-                std::cerr << "Non dynamic buffer offset individual draw is only implemented for "
-                             "dawn backend."
+                std::cerr << "Disable dynamic buffer offset is only implemented for dawn backend."
                           << std::endl;
                 return false;
             }
+            toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLEDYNAMICBUFFEROFFSET));
+        }
+        else if (cmd == "--integrated-gpu")
+        {
+            if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU)) &&
+                !availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEDGPU)))
+            {
+                std::cerr << "Dynamically choose gpu isn't supported for the backend." << std::endl;
+                return false;
+            }
+
+            if (toggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEDGPU)))
+            {
+                std::cerr << "Integrated and Discreted gpu cannot be used simultaneosly.";
+            }
+            toggleBitset.set(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
+        }
+        else if (cmd == "--discreted-gpu")
+        {
+            if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU)) &&
+                !availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEDGPU)))
+            {
+                std::cerr << "Dynamically choose gpu isn't supported for the backend." << std::endl;
+                return false;
+            }
+
+            if (toggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU)))
+            {
+                std::cerr << "Integrated and Discreted gpu cannot be used simultaneosly.";
+            }
+
+            toggleBitset.set(static_cast<size_t>(TOGGLE::DISCRETEDGPU));
         }
         else
         {
         }
     }
 
-    if (context == nullptr)
-    {
-        mBackendType = BACKENDTYPE::BACKENDTYPEOPENGL;
-        mBackendFullpath = "opengl";
-        context      = factory->createContext(mBackendType);
-    }
-
-    if (mBackendType == BACKENDTYPE::BACKENDTYPEOPENGL || mBackendType == BACKENDTYPE::BACKENDTYPEANGLE)
-    {
-#ifndef EGL_EGL_PROTOTYPES
-        mShaderVersion = "450";
-#else
-        mShaderVersion = "100";
-        mBackendFullpath = "opengl";
-#endif
-    }
-
-    if (!context->createContext(mBackendType, enableMSAA))
+    if (!context->initialize(mBackendType, toggleBitset))
     {
         return false;
     }
 
     calculateFishCount();
-    updateUrls();
 
     std::cout << "Init resources ..." << std::endl;
     getElapsedTime();
 
+    const ResourceHelper *resourceHelper = context->getResourceHelper();
+    std::vector<std::string> skyUrls;
+    resourceHelper->getSkyBoxUrls(&skyUrls);
     mTextureMap["skybox"] = context->createTexture("skybox", skyUrls);
 
     // Init general buffer and binding groups for dawn backend.
@@ -300,46 +302,6 @@ void Aquarium::display()
     context->Terminate();
 }
 
-void Aquarium::updateUrls()
-{
-// Get path of current build.
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
-    TCHAR temp[200];
-    GetModuleFileName(nullptr, temp, MAX_PATH);
-    std::wstring ws(temp);
-    mPath       = std::string(ws.begin(), ws.end());
-    size_t nPos = mPath.find_last_of(slash);
-    mPath       = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
-#elif __APPLE__
-    char temp[200];
-    uint32_t size = sizeof(temp);
-    _NSGetExecutablePath(temp, &size);
-    mPath = std::string(temp);
-    int nPos = mPath.find_last_of(slash);
-    mPath = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
-#else
-    char temp[200];
-    readlink("/proc/self/exe", temp, sizeof(temp));
-    mPath    = std::string(temp);
-    int nPos = mPath.find_last_of(slash);
-    mPath    = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
-#endif
-
-    // set up skybox url
-    setUpSkyBox(&skyUrls);
-}
-
-void Aquarium::setUpSkyBox(std::vector<std::string> *skyUrls)
-{
-    for (const auto v : g_skyBoxUrls)
-    {
-        std::ostringstream url;
-        url << mPath << resourceFolder << slash << v;
-
-        skyUrls->push_back(url.str());
-    }
-}
-
 void Aquarium::loadReource()
 {
     loadModels();
@@ -357,9 +319,8 @@ void Aquarium::setupModelEnumMap()
 // Load world matrices of models from json file.
 void Aquarium::loadPlacement()
 {
-    std::ostringstream oss;
-    oss << mPath << resourceFolder << slash << "PropPlacement.js";
-    std::string proppath = oss.str();
+    const ResourceHelper *resourceHelper = context->getResourceHelper();
+    std::string proppath                 = resourceHelper->getPropPlacementPath();
     std::ifstream PlacementStream(proppath, std::ios::in);
     rapidjson::IStreamWrapper isPlacement(PlacementStream);
     rapidjson::Document document;
@@ -394,10 +355,11 @@ void Aquarium::loadPlacement()
 
 void Aquarium::loadModels()
 {
+    bool enableInstanceddraw = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
     for (const auto &info : g_sceneInfo)
     {
-        if ((allowInstancedDraws && info.type == MODELGROUP::FISH) ||
-            (!allowInstancedDraws && info.type == MODELGROUP::FISHINSTANCEDDRAW))
+        if ((enableInstanceddraw && info.type == MODELGROUP::FISH) ||
+            ((!enableInstanceddraw) && info.type == MODELGROUP::FISHINSTANCEDDRAW))
         {
             continue;
         }
@@ -408,14 +370,10 @@ void Aquarium::loadModels()
 // Load vertex and index buffers, textures and program for each model.
 void Aquarium::loadModel(const G_sceneInfo &info)
 {
-    std::ostringstream oss;
-    oss << mPath << resourceFolder << slash;
-    std::string imagePath = oss.str();
-    oss << info.namestr << ".js";
-    std::string modelPath = oss.str();
-    oss.str("");
-    oss << mPath << shaderFolder << slash << mBackendFullpath << slash << mShaderVersion << slash;
-    std::string programPath = oss.str();
+    const ResourceHelper *resourceHelper = context->getResourceHelper();
+    const std::string &imagePath         = resourceHelper->getImagePath();
+    const std::string &programPath       = resourceHelper->getProgramPath();
+    const std::string &modelPath         = resourceHelper->getModelPath(std::string(info.namestr));
 
     std::ifstream ModelStream(modelPath, std::ios::in);
     rapidjson::IStreamWrapper is(ModelStream);
@@ -694,10 +652,15 @@ void Aquarium::drawSeaweed()
 
 void Aquarium::drawFishes()
 {
-    int begin =
-        allowInstancedDraws ? MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS : MODELNAME::MODELSMALLFISHA;
-    int end =
-        allowInstancedDraws ? MODELNAME::MODELBIGFISHBINSTANCEDDRAWS : MODELNAME::MODELBIGFISHB;
+    int begin = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
+                    ? MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS
+                    : MODELNAME::MODELSMALLFISHA;
+    int end = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
+                  ? MODELNAME::MODELBIGFISHBINSTANCEDDRAWS
+                  : MODELNAME::MODELBIGFISHB;
+    bool updateAndDrawForEachFish =
+        toggleBitset.test(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
+
     for (int i = begin; i <= end; ++i)
     {
         FishModel *model = static_cast<FishModel *>(mAquariumModels[i]);
@@ -705,7 +668,7 @@ void Aquarium::drawFishes()
         const Fish &fishInfo = fishTable[i - begin];
         int numFish          = fishCount[i - begin];
 
-        if (mBackendType == BACKENDTYPE::BACKENDTYPEOPENGL || mBackendType == BACKENDTYPE::BACKENDTYPEANGLE)
+        if (updateAndDrawForEachFish)
         {
             model->preDraw();
         }
@@ -746,7 +709,7 @@ void Aquarium::drawFishes()
                 fmod((g.mclock + ii * g_tailOffsetMult) * fishTailSpeed * speed,
                      static_cast<float>(M_PI) * 2),
                 ii);
-            if (mBackendType == BACKENDTYPEOPENGL || mBackendType == BACKENDTYPEANGLE)
+            if (updateAndDrawForEachFish)
             {
                 model->updatePerInstanceUniforms(&worldUniforms);
                 model->draw();
@@ -755,8 +718,7 @@ void Aquarium::drawFishes()
         // TODO(yizhou): If backend is dawn or d3d12, draw only once for every type of fish by
         // drawInstance. If backend is opengl or angle, draw for exery fish. Update the logic the
         // same as Dawn if uniform blocks are implemented for OpenGL.
-        if (mBackendType == BACKENDTYPEDAWND3D12 || mBackendType == BACKENDTYPED3D12 ||
-            mBackendType == BACKENDTYPEDAWNVULKAN || mBackendType == BACKENDTYPEDAWNMETAL)
+        if (!updateAndDrawForEachFish)
         {
             model->draw();
         }
@@ -786,16 +748,15 @@ void Aquarium::updateWorldProjections(const float *w)
 
 void Aquarium::updateWorldMatrixAndDraw(Model *model)
 {
+    bool updateAndDrawForEachFish =
+        toggleBitset.test(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
+
     if (model->worldmatrices.size())
     {
         for (auto &world : model->worldmatrices)
         {
             updateWorldProjections(world.data());
-            // Models of dawn keep WorldUniforms for every model while opengl models use global
-            // WorldUniforms.
-            // Update all WorldUniforms on dawn backend.
-            if (mBackendType == BACKENDTYPE::BACKENDTYPEOPENGL ||
-                mBackendType == BACKENDTYPE::BACKENDTYPEANGLE)
+            if (updateAndDrawForEachFish)
             {
                 model->preDraw();
                 model->updatePerInstanceUniforms(&worldUniforms);
@@ -808,11 +769,7 @@ void Aquarium::updateWorldMatrixAndDraw(Model *model)
         }
     }
 
-    // TODO(yizhou): If backend is dawn, draw only once for every model. If
-    // backend is opengl or angle, draw for exery instance.
-    // Update the logic the same as Dawn if uniform blocks are implemented for OpenGL.
-    if (mBackendType == BACKENDTYPEDAWND3D12 || mBackendType == BACKENDTYPED3D12 ||
-        mBackendType == BACKENDTYPEDAWNVULKAN || mBackendType == BACKENDTYPEDAWNMETAL)
+    if (!updateAndDrawForEachFish)
     {
         model->preDraw();
         model->draw();

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -8,6 +8,7 @@
 #ifndef AQUARIUM_H
 #define AQUARIUM_H
 
+#include <bitset>
 #include <string>
 #include <unordered_map>
 
@@ -29,7 +30,6 @@ const std::string slash = "/";
 
 enum BACKENDTYPE : short
 {
-    BACKENDTYPEFIRST,
     BACKENDTYPEANGLE,
     BACKENDTYPEDAWND3D12,
     BACKENDTYPEDAWNMETAL,
@@ -104,6 +104,26 @@ enum FISHENUM : short
     MEDIUM,
     SMALL,
     MAX
+};
+
+enum TOGGLE : short
+{
+    // Enable 4 times MSAA.
+    ENABLEMSAAx4,
+    // Go through instanced draw.
+    ENABLEINSTANCEDDRAWS,
+    // The toggle is only supported on Dawn backend.
+    // By default, the app will enable dynamic buffer offset.
+    // The toggle is to disable dbo feature.
+    DISABLEDYNAMICBUFFEROFFSET,
+    // Select integrated gpu if available.
+    INTEGRATEDGPU,
+    // Select discreted gpu if available.
+    DISCRETEDGPU,
+    // Update and draw for each model on OpenGL and Angle backend, but draw once per frame on other
+    // backend.
+    UPATEANDDRAWFOREACHMODEL,
+    TOGGLEMAX
 };
 
 const G_sceneInfo g_sceneInfo[] = {
@@ -205,10 +225,6 @@ const G_sceneInfo g_sceneInfo[] = {
      MODELGROUP::OUTSIDE},
     {"SupportBeams", MODELNAME::MODELSUPPORTBEAMS, {"", ""}, false, MODELGROUP::OUTSIDE},
     {"TreasureChest", MODELNAME::MODELTREASURECHEST, {"", ""}, true, MODELGROUP::GENERIC}};
-
-const std::vector<std::string> g_skyBoxUrls = {
-    "GlobeOuter_EM_positive_x.jpg", "GlobeOuter_EM_negative_x.jpg", "GlobeOuter_EM_positive_y.jpg",
-    "GlobeOuter_EM_negative_y.jpg", "GlobeOuter_EM_positive_z.jpg", "GlobeOuter_EM_negative_z.jpg"};
 
 struct Fish
 {
@@ -414,8 +430,8 @@ class Aquarium
     bool init(int argc, char **argv);
     void display();
     Texture *getSkybox() { return mTextureMap["skybox"]; }
-    bool getEnableDynamicBufferOffset() { return enableDynamicBufferOffset; }
 
+    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> toggleBitset;
     LightWorldPositionUniform lightWorldPositionUniform;
     WorldUniforms worldUniforms;
     LightUniforms lightUniforms;
@@ -433,22 +449,14 @@ class Aquarium
     FPSTimer fpsTimer;  // object to measure frames per second;
     int mFishCount;
     BACKENDTYPE mBackendType;
-    std::string mBackendFullpath;
-    std::string mShaderVersion;
-    std::string mPath;
     ContextFactory *factory;
-    bool enableMSAA;
-    bool allowInstancedDraws;
-    bool enableDynamicBufferOffset;
     std::vector<std::string> skyUrls;
 
-    void updateUrls();
     void loadReource();
     void loadPlacement();
     void loadModels();
     void loadModel(const G_sceneInfo &info);
     void setupModelEnumMap();
-    void setUpSkyBox(std::vector<std::string> *skyUrls);
     void calculateFishCount();
     float degToRad(float degrees);
     void updateWorldMatrixAndDraw(Model *model);

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -9,8 +9,12 @@
 #ifndef Context_H
 #define Context_H 1
 
+#include <bitset>
 #include <string>
 #include <vector>
+
+#include "Aquarium.h"
+#include "ResourceHelper.h"
 
 class Aquarium;
 class Program;
@@ -21,41 +25,56 @@ class Model;
 enum BACKENDTYPE : short;
 enum MODELGROUP : short;
 enum MODELNAME : short;
+enum TOGGLE : short;
+
 struct Global;
 
 class Context
 {
   public:
-    Context(){}
-    virtual bool createContext(BACKENDTYPE backend, bool enableMSAA) = 0;
+    Context() {}
     virtual ~Context() {}
-    virtual Texture *createTexture(std::string name, std::string url)                      = 0;
-    virtual Texture *createTexture(std::string name, const std::vector<std::string> &urls) = 0;
+    virtual bool initialize(
+        BACKENDTYPE backend,
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)              = 0;
+    virtual Texture *createTexture(std::string name, std::string url)                         = 0;
+    virtual Texture *createTexture(std::string name, const std::vector<std::string> &urls)    = 0;
     virtual Buffer *createBuffer(int numComponents, std::vector<float> &buffer, bool isIndex) = 0;
     virtual Buffer *createBuffer(int numComponents,
                                  std::vector<unsigned short> &buffer,
                                  bool isIndex)                                                = 0;
-    virtual Program *createProgram(std::string vId, std::string fId)                       = 0;
-    virtual void setWindowTitle(const std::string &text)                                   = 0;
-    virtual bool ShouldQuit()                                                              = 0;
-    virtual void KeyBoardQuit()                                                            = 0;
-    virtual void DoFlush()                                                                 = 0;
-    virtual void Terminate()                                                               = 0;
+    virtual Program *createProgram(std::string vId, std::string fId)                          = 0;
+    virtual void setWindowTitle(const std::string &text)                                      = 0;
+    virtual bool ShouldQuit()                                                                 = 0;
+    virtual void KeyBoardQuit()                                                               = 0;
+    virtual void DoFlush()                                                                    = 0;
+    virtual void Terminate()                                                                  = 0;
     virtual void FlushInit() {}
-    virtual void preFrame() = 0;
+    virtual void preFrame()   = 0;
     virtual void showWindow() = 0;
 
     int getClientWidth() const { return mClientWidth; }
     int getclientHeight() const { return mClientHeight; }
+    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> getAvailableToggleBitset()
+    {
+        return mAvailableToggleBitset;
+    }
 
     virtual Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) = 0;
 
-    virtual void initGeneralResources(Aquarium* aquarium) {}
-    virtual void updateWorldlUniforms(Aquarium* aquarium) {}
+    virtual void initGeneralResources(Aquarium *aquarium) {}
+    virtual void updateWorldlUniforms(Aquarium *aquarium) {}
+
+    const ResourceHelper *getResourceHelper() { return mResourceHelper; }
 
   protected:
     int mClientWidth;
     int mClientHeight;
+
+    ResourceHelper *mResourceHelper;
+
+    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> mAvailableToggleBitset;
+    virtual void initAvailableToggleBitset() = 0;
 };
 
 #endif

--- a/src/aquarium-optimized/ResourceHelper.cpp
+++ b/src/aquarium-optimized/ResourceHelper.cpp
@@ -1,0 +1,82 @@
+#include "ResourceHelper.h"
+
+#include <sstream>
+#ifdef _WIN32
+#include <direct.h>
+#include "Windows.h"
+const std::string slash = "\\";
+#elif __APPLE__
+#include <mach-o/dyld.h>
+const std::string slash = "/";
+#else
+#include <unistd.h>
+const std::string slash = "/";
+#endif
+
+static const char *shaderFolder   = "shaders";
+static const char *resourceFolder = "assets";
+
+const std::vector<std::string> skyBoxUrls = {
+    "GlobeOuter_EM_positive_x.jpg", "GlobeOuter_EM_negative_x.jpg", "GlobeOuter_EM_positive_y.jpg",
+    "GlobeOuter_EM_negative_y.jpg", "GlobeOuter_EM_positive_z.jpg", "GlobeOuter_EM_negative_z.jpg"};
+
+ResourceHelper::ResourceHelper(const std::string &mBackendName, const std::string &mShaderVersion)
+    : mBackendName(mBackendName), mShaderVersion(mShaderVersion)
+{
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
+    TCHAR temp[200];
+    GetModuleFileName(nullptr, temp, MAX_PATH);
+    std::wstring ws(temp);
+    mPath = std::string(ws.begin(), ws.end());
+#elif __APPLE__
+    char temp[200];
+    uint32_t size = sizeof(temp);
+    _NSGetExecutablePath(temp, &size);
+    mPath = std::string(temp);
+#else
+    char temp[200];
+    readlink("/proc/self/exe", temp, sizeof(temp));
+    mPath = std::string(temp);
+#endif
+
+    size_t nPos = mPath.find_last_of(slash);
+    std::ostringstream pathStream;
+    pathStream << mPath.substr(0, nPos) << slash << ".." << slash << ".." << slash;
+    mPath = pathStream.str();
+
+    std::ostringstream placementStream;
+    placementStream << mPath << resourceFolder << slash << "PropPlacement.js";
+    mPropPlacementPath = placementStream.str();
+
+    std::ostringstream imageStream;
+    imageStream << mPath << resourceFolder << slash;
+    mImagePath = imageStream.str();
+}
+
+void ResourceHelper::getSkyBoxUrls(std::vector<std::string> *skyUrls) const
+{
+    for (auto &str : skyBoxUrls)
+    {
+        std::ostringstream url;
+        url << mPath << resourceFolder << slash << str;
+
+        skyUrls->emplace_back(url.str());
+    }
+}
+
+std::string ResourceHelper::getModelPath(const std::string &modelName) const
+{
+    std::ostringstream modelStream;
+    modelStream << mImagePath << modelName << ".js";
+    std::string modelPath = modelStream.str();
+    return modelPath;
+}
+
+std::string ResourceHelper::getProgramPath() const
+{
+    std::ostringstream programStream;
+    programStream << mPath << shaderFolder << slash << mBackendName << slash << mShaderVersion
+                  << slash;
+    std::string programPath = programStream.str();
+    return programPath;
+}

--- a/src/aquarium-optimized/ResourceHelper.h
+++ b/src/aquarium-optimized/ResourceHelper.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <string>
+#include <vector>
+
+class ResourceHelper
+{
+  public:
+    ResourceHelper() {}
+    ResourceHelper(const std::string &mBackendName, const std::string &mShaderVersion);
+    void getSkyBoxUrls(std::vector<std::string> *skyUrls) const;
+    const std::string &getPropPlacementPath() const { return mPropPlacementPath; }
+    const std::string &getImagePath() const { return mImagePath; }
+    std::string getModelPath(const std::string &modelName) const;
+    std::string getProgramPath() const;
+
+  private:
+    std::string mPath;
+    std::string mImagePath;
+    std::string mProgramPath;
+    std::string mPropPlacementPath;
+    std::string mBackendName;
+    std::string mShaderVersion;
+};

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -26,7 +26,9 @@ class ContextD3D12 : public Context
   public:
     ContextD3D12();
     ~ContextD3D12();
-    bool createContext(BACKENDTYPE backend, bool enableMSAA) override;
+    bool initialize(
+        BACKENDTYPE backend,
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
     void setWindowTitle(const std::string &text) override;
     bool ShouldQuit() override;
     void KeyBoardQuit() override;
@@ -114,12 +116,16 @@ class ContextD3D12 : public Context
     std::vector<CD3DX12_STATIC_SAMPLER_DESC> staticSamplers;
 
   private:
-    void GetHardwareAdapter(IDXGIFactory2 *pFactory, IDXGIAdapter1 **ppAdapter);
+    bool GetHardwareAdapter(
+        IDXGIFactory2 *pFactory,
+        IDXGIAdapter1 **ppAdapter,
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
     void WaitForPreviousFrame();
     void createDepthStencilView();
     void stateTransition(ComPtr<ID3D12Resource> &resource,
                          D3D12_RESOURCE_STATES preState,
                          D3D12_RESOURCE_STATES transferState) const;
+    void initAvailableToggleBitset() override;
 
     GLFWwindow *mWindow;
     ComPtr<ID3D12Device> m_device;

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -50,6 +50,8 @@ ContextDawn::ContextDawn()
       device(nullptr),
       mEnableMSAA(false)
 {
+    mResourceHelper = new ResourceHelper("dawn", "");
+    initAvailableToggleBitset();
 }
 
 ContextDawn::~ContextDawn()
@@ -75,7 +77,9 @@ ContextDawn::~ContextDawn()
     device                   = nullptr;
 }
 
-bool ContextDawn::createContext(BACKENDTYPE backend, bool enableMSAA)
+bool ContextDawn::initialize(
+    BACKENDTYPE backend,
+    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {
     dawn_native::BackendType backendType = dawn_native::BackendType::Null;
 
@@ -104,10 +108,11 @@ bool ContextDawn::createContext(BACKENDTYPE backend, bool enableMSAA)
         default:
         {
             std::cerr << "Backend type can not reached." << std::endl;
+            return false;
         }
     }
 
-    mEnableMSAA = enableMSAA;
+    mEnableMSAA = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEMSAAx4));
 
     // initialise GLFW
     if (!glfwInit())
@@ -139,17 +144,10 @@ bool ContextDawn::createContext(BACKENDTYPE backend, bool enableMSAA)
     instance = std::make_unique<dawn_native::Instance>();
     utils::DiscoverAdapter(instance.get(), mWindow, backendType);
 
-    // Get an adapter for the backend to use, and create the device.
     dawn_native::Adapter backendAdapter;
+    if (!GetHardwareAdapter(instance, &backendAdapter, backendType, toggleBitset))
     {
-        for (auto &adapter : instance->GetAdapters())
-        {
-            if (adapter.GetBackendType() == backendType)
-            {
-                backendAdapter = adapter;
-                break;
-            }
-        }
+        return false;
     }
 
     DawnDevice backendDevice   = backendAdapter.CreateDevice();
@@ -197,6 +195,53 @@ bool ContextDawn::createContext(BACKENDTYPE backend, bool enableMSAA)
     mSceneDepthStencilView = createDepthStencilView();
 
     return true;
+}
+
+bool ContextDawn::GetHardwareAdapter(
+    std::unique_ptr<dawn_native::Instance> &instance,
+    dawn_native::Adapter *backendAdapter,
+    dawn_native::BackendType backendType,
+    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
+{
+    bool enableIntegratedGpu = toggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
+    bool enableDiscretedGpu  = toggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEDGPU));
+    bool useDefaultGpu      = (enableDiscretedGpu | enableIntegratedGpu) == false ? true : false;
+    bool result             = false;
+
+    // Get an adapter for the backend to use, and create the device.
+    for (auto &adapter : instance->GetAdapters())
+    {
+        if (adapter.GetBackendType() == backendType)
+        {
+            if (useDefaultGpu ||
+                (enableDiscretedGpu &&
+                 adapter.GetDeviceType() == dawn_native::DeviceType::DiscreteGPU) ||
+                (enableIntegratedGpu &&
+                 adapter.GetDeviceType() == dawn_native::DeviceType::IntegratedGPU))
+            {
+                *backendAdapter = adapter;
+                result          = true;
+                break;
+            }
+        }
+    }
+
+    if (!result)
+    {
+        std::cerr << "Failed to create adapter." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+void ContextDawn::initAvailableToggleBitset()
+{
+    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEMSAAx4));
+    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
+    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DISABLEDYNAMICBUFFEROFFSET));
+    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DISCRETEDGPU));
+    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
 }
 
 Texture *ContextDawn::createTexture(std::string name, std::string url)

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -27,7 +27,9 @@ class ContextDawn : public Context
   public:
     ContextDawn();
     ~ContextDawn();
-    bool createContext(BACKENDTYPE backend, bool enableMSAA) override;
+    bool initialize(
+        BACKENDTYPE backend,
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
     void setWindowTitle(const std::string &text) override;
     bool ShouldQuit() override;
     void KeyBoardQuit() override;
@@ -91,6 +93,13 @@ class ContextDawn : public Context
     dawn::BindGroup bindGroupWorld;
 
   private:
+    bool GetHardwareAdapter(
+        std::unique_ptr<dawn_native::Instance> &instance,
+        dawn_native::Adapter *backendAdapter,
+        dawn_native::BackendType backendType,
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
+    void initAvailableToggleBitset() override;
+
     GLFWwindow *mWindow;
     std::unique_ptr<dawn_native::Instance> instance;
 

--- a/src/aquarium-optimized/dawn/FishModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelDawn.cpp
@@ -13,11 +13,12 @@ FishModelDawn::FishModelDawn(const Context *context,
                              MODELGROUP type,
                              MODELNAME name,
                              bool blend)
-    : FishModel(type, name, blend),
-      instance(0),
-      enableDynamicBufferOffset(aquarium->getEnableDynamicBufferOffset())
+    : FishModel(type, name, blend), instance(0)
 {
     contextDawn = static_cast<const ContextDawn *>(context);
+
+    enableDynamicBufferOffset =
+        !aquarium->toggleBitset.test(static_cast<size_t>(TOGGLE::DISABLEDYNAMICBUFFEROFFSET));
 
     lightFactorUniforms.shininess      = 5.0f;
     lightFactorUniforms.specularFactor = 0.3f;

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -35,7 +35,9 @@ class ContextGL : public Context
   public:
     ContextGL();
     ~ContextGL();
-    bool createContext(BACKENDTYPE backend, bool enableMSAA) override;
+    bool initialize(
+        BACKENDTYPE backend,
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
     void setWindowTitle(const std::string &text) override;
     bool ShouldQuit() override;
     void KeyBoardQuit() override;
@@ -91,6 +93,7 @@ class ContextGL : public Context
 
   private:
     void initState();
+    void initAvailableToggleBitset() override;
 
     GLFWwindow *mWindow;
 

--- a/src/include/CmdArgsHelper.h
+++ b/src/include/CmdArgsHelper.h
@@ -1,9 +1,9 @@
 //
-// Copyright (c) 2018 The WebGLNativePorts Project Authors. All rights reserved.
+// Copyright (c) 2019 The WebGLNativePorts Project Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// FPSTimer.h: Define fps timer.
+// CmdArgsHelper.h: Define cmd arg strings.
 
 #pragma once
 #ifndef CMDARGSHELPER


### PR DESCRIPTION
Add instanced, DBO, MSAA, INTEGRATED or DISCREATED
gpu to toggle.

Implement choose gpu by passing cmd args. The feature is
only supported on Dawn and D3D12 now.
To choose integrated or discreted gpu,
pass cmd args, '--integrated-gpu' or '--discreted-gpu'