### PR TITLE
Use dotfile to override warnnig errors for working around shaderc issue

### DIFF
--- a/.gn
+++ b/.gn
@@ -8,6 +8,7 @@ buildconfig = "//build/config/BUILDCONFIG.gn"
 
 default_args = {
   clang_use_chrome_plugins = false
+  treat_warnings_as_errors = false
 }
 
 check_targets = [


### PR DESCRIPTION
Adding treat_warnings_as_errors = false in .gn file to override default args.