### PR TITLE
Code clean up

### DIFF
--- a/src/aquarium-direct-map/AttribBuffer.cpp
+++ b/src/aquarium-direct-map/AttribBuffer.cpp
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// AttribBuffer.cpp: Implements AttribBuffer.
+// AttribBuffer.cpp: Implement AttribBuffer.
 
 #include "AttribBuffer.h"
 

--- a/src/aquarium-direct-map/Buffer.cpp
+++ b/src/aquarium-direct-map/Buffer.cpp
@@ -3,11 +3,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// Buffer.cpp: Implements the index or vertex buffer wrappers and resource bindings of OpenGL.
-
-#include "Buffer.h"
+// Buffer.cpp: Implement the index or vertex buffer wrappers and resource bindings of OpenGL.
 
 #include <iostream>
+
+#include "Buffer.h"
 
 #include "common/AQUARIUM_ASSERT.h"
 

--- a/src/aquarium-direct-map/Globals.h
+++ b/src/aquarium-direct-map/Globals.h
@@ -16,8 +16,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "common/FPSTimer.h"
 #include "Scene.h"
+
+#include "common/FPSTimer.h"
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 const std::string slash = "\\";

--- a/src/aquarium-direct-map/Main.cpp
+++ b/src/aquarium-direct-map/Main.cpp
@@ -29,14 +29,14 @@
 #include "Matrix.h"
 #include "Model.h"
 #include "Program.h"
+
+#include "GLFW/glfw3.h"
 #include "common/AQUARIUM_ASSERT.h"
 #include "include/CmdArgsHelper.h"
 #include "rapidjson/document.h"
 #include "rapidjson/istreamwrapper.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
-
-#include "GLFW/glfw3.h"
 
 #define min(a,b) ((a)<(b)?(a):(b))
 
@@ -468,7 +468,7 @@ void DrawGroup(std::multimap<std::string, std::vector<float>> &group,
             if (model != currentModel)
             {
                 currentModel = model;
-                model->drawPrep(constUniforms);
+                model->prepareForDraw(constUniforms);
             }
 
             world = std::vector<float>(object.second.begin(), object.second.end());
@@ -602,7 +602,7 @@ void render() {
             Model *fish             = scene->getModels()[0];
             auto &f                 = g["fish"];
             fishConst.constUniforms = fishInfo.constUniforms;
-            fish->drawPrep(fishConst);
+            fish->prepareForDraw(fishConst);
             float fishBaseClock                  = mClock * f["fishSpeed"];
             float fishRadius                     = fishInfo.radius;
             float fishRadiusRange                = fishInfo.radiusRange;

--- a/src/aquarium-direct-map/Model.cpp
+++ b/src/aquarium-direct-map/Model.cpp
@@ -7,9 +7,9 @@
 // Update uniforms, textures and buffers for each frame.
 
 #include "Model.h"
+#include "Globals.h"
 
 #include "common/AQUARIUM_ASSERT.h"
-#include "Globals.h"
 
 Model::Model(Program *program_,
              std::unordered_map<std::string, AttribBuffer *> *arrays,
@@ -89,7 +89,7 @@ void Model::applyTextures() const
     }
 }
 
-void Model::drawPrep(const GenericConst &constUniforms)
+void Model::prepareForDraw(const GenericConst &constUniforms)
 {
     program->use();
 
@@ -116,9 +116,9 @@ void Model::drawPrep(const GenericConst &constUniforms)
     program->setUniform("tankColorFudge", constUniforms.tankColorFudge);
 }
 
-void Model::drawPrep(const FishConst &fishConst)
+void Model::prepareForDraw(const FishConst &fishConst)
 {
-    drawPrep(fishConst.genericConst);
+    prepareForDraw(fishConst.genericConst);
 
     program->setUniform("fishBendAmount", fishConst.constUniforms.fishBendAmount);
     program->setUniform("fishLength", fishConst.constUniforms.fishLength);

--- a/src/aquarium-direct-map/Model.h
+++ b/src/aquarium-direct-map/Model.h
@@ -30,8 +30,8 @@ public:
         std::unordered_map<std::string, AttribBuffer *> *arrays,
         std::unordered_map<std::string, Texture *> *textures);
 
-  void drawPrep(const GenericConst &constUniforms);
-  void drawPrep(const FishConst &fishConst);
+  void prepareForDraw(const GenericConst &constUniforms);
+  void prepareForDraw(const FishConst &fishConst);
   void draw(const GenericPer &perUniforms);
   void draw(const FishPer &fishPer);
 

--- a/src/aquarium-direct-map/Program.cpp
+++ b/src/aquarium-direct-map/Program.cpp
@@ -8,12 +8,12 @@
 // Compiles OpenGL shaders and check if compiled success.
 // Apply Buffers, Textures and Uniforms to program.
 
-#include "Program.h"
-
 #include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <regex>
+
+#include "Program.h"
 
 #include "common/AQUARIUM_ASSERT.h"
 

--- a/src/aquarium-direct-map/Scene.cpp
+++ b/src/aquarium-direct-map/Scene.cpp
@@ -6,8 +6,6 @@
 // Scene.cpp: Implements Scene.
 // Load resources including images, vertexes and programs, then group them into models.
 
-#include "Scene.h"
-
 #include <cstdio>
 #include <fstream>
 #include <iostream>
@@ -17,6 +15,8 @@
 #include "Globals.h"
 #include "Model.h"
 #include "Program.h"
+#include "Scene.h"
+
 #include "rapidjson/document.h"
 #include "rapidjson/filereadstream.h"
 #include "rapidjson/istreamwrapper.h"

--- a/src/aquarium-direct-map/Texture.cpp
+++ b/src/aquarium-direct-map/Texture.cpp
@@ -6,9 +6,9 @@
 // Texture.cpp: Load images by stb lib, flip the texture if needed.
 // Create texture2D or textureCubeMap, then upload the texture to gpu.
 
-#include "Texture.h"
-
 #include <iostream>
+
+#include "Texture.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -4,16 +4,15 @@
 // found in the LICENSE file.
 //
 // Aquarium.cpp: Create context for specific graphics API.
-// Data preparation, load vertex and index buffer, images and shders.
+// Data preparation, load vertex and index buffer, images and shaders.
 // Implements logic of rendering background, fishes, seaweeds and
 // other models. Calculate fish count for each type of fish.
 // Update uniforms for each frame.
 
-#include <iostream>
-
 #include <algorithm>
 #include <cmath>
 #include <fstream>
+#include <iostream>
 
 #include "Aquarium.h"
 #include "ContextFactory.h"
@@ -22,9 +21,11 @@
 #include "Program.h"
 #include "SeaweedModel.h"
 #include "Texture.h"
+
 #include "common/AQUARIUM_ASSERT.h"
 #include "include/CmdArgsHelper.h"
 #include "opengl/ContextGL.h"
+
 #include "rapidjson/document.h"
 #include "rapidjson/istreamwrapper.h"
 #include "rapidjson/stringbuffer.h"
@@ -668,7 +669,7 @@ void Aquarium::drawFishes()
 
         if (updateAndDrawForEachFish)
         {
-            model->preDraw();
+            model->prepareForDraw();
         }
 
         float fishBaseClock   = g.mclock * g_fishSpeed;
@@ -756,7 +757,7 @@ void Aquarium::updateWorldMatrixAndDraw(Model *model)
             updateWorldProjections(world.data());
             if (updateAndDrawForEachFish)
             {
-                model->preDraw();
+                model->prepareForDraw();
                 model->updatePerInstanceUniforms(&worldUniforms);
                 model->draw();
             }
@@ -769,7 +770,7 @@ void Aquarium::updateWorldMatrixAndDraw(Model *model)
 
     if (!updateAndDrawForEachFish)
     {
-        model->preDraw();
+        model->prepareForDraw();
         model->draw();
     }
 }

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -14,8 +14,9 @@
 #include <vector>
 
 #include "Aquarium.h"
-#include "common/FPSTimer.h"
 #include "ResourceHelper.h"
+
+#include "common/FPSTimer.h"
 
 class Aquarium;
 class Program;

--- a/src/aquarium-optimized/ContextFactory.cpp
+++ b/src/aquarium-optimized/ContextFactory.cpp
@@ -3,7 +3,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
+
+#include "Aquarium.h"
 #include "ContextFactory.h"
+
 #include "opengl/ContextGL.h"
 #ifdef ENABLE_DAWN_BACKEND
 #include "dawn/ContextDawn.h"
@@ -11,8 +14,6 @@
 #ifdef ENABLE_D3D12_BACKEND
 #include "d3d12/ContextD3D12.h"
 #endif
-
-#include "Aquarium.h"
 
 ContextFactory::ContextFactory()
     :context(nullptr)

--- a/src/aquarium-optimized/ContextFactory.h
+++ b/src/aquarium-optimized/ContextFactory.h
@@ -7,8 +7,6 @@
 
 #ifndef CONTEXTFACTORY
 #define CONTEXTFACTORY 1
-#include <string>
-#include "Context.h"
 
 class Context;
 enum BACKENDTYPE : short;

--- a/src/aquarium-optimized/FishModel.h
+++ b/src/aquarium-optimized/FishModel.h
@@ -9,8 +9,6 @@
 #ifndef FISHMODEL_H
 #define FISHMODEL_H 1
 
-#include <string>
-
 #include "Model.h"
 
 class FishModel : public Model

--- a/src/aquarium-optimized/Model.cpp
+++ b/src/aquarium-optimized/Model.cpp
@@ -5,10 +5,9 @@
 //
 // Model.cpp: Implement common functions of Model.
 
-#include "Model.h"
-
 #include "Aquarium.h"
 #include "Buffer.h"
+#include "Model.h"
 
 Model::Model()
     : mProgram(nullptr),

--- a/src/aquarium-optimized/Model.h
+++ b/src/aquarium-optimized/Model.h
@@ -12,8 +12,7 @@
 #ifndef MODEL_H
 #define MODEL_H 1
 
-#include <cstdio>
-#include <cstring>
+#include <string>
 #include <vector>
 
 #include "Aquarium.h"
@@ -34,7 +33,7 @@ class Model
     Model(MODELGROUP type, MODELNAME name, bool blend)
         : mProgram(nullptr), mBlend(blend), mName(name) {}
     virtual ~Model();
-    virtual void preDraw() const     = 0;
+    virtual void prepareForDraw() const     = 0;
     virtual void updatePerInstanceUniforms(WorldUniforms* worldUniforms) = 0;
     virtual void draw() = 0;
 
@@ -50,8 +49,6 @@ class Model
     bool mBlend;
     MODELNAME mName;
 
-  private:
-    //MODELGROUP mType;
 };
 
 #endif

--- a/src/aquarium-optimized/Program.h
+++ b/src/aquarium-optimized/Program.h
@@ -9,7 +9,6 @@
 #define PROGRAM_H 1
 
 #include <string>
-#include <vector>
 
 enum UNIFORMNAME : short;
 

--- a/src/aquarium-optimized/ResourceHelper.cpp
+++ b/src/aquarium-optimized/ResourceHelper.cpp
@@ -1,6 +1,7 @@
 #include "ResourceHelper.h"
 
 #include <sstream>
+
 #ifdef _WIN32
 #include <direct.h>
 #include "Windows.h"

--- a/src/aquarium-optimized/Texture.cpp
+++ b/src/aquarium-optimized/Texture.cpp
@@ -9,8 +9,7 @@
 
 #include <algorithm>
 #include <iostream>
-#include <cstdio>
-#include <cstring>
+#include <string>
 
 #include "../common/AQUARIUM_ASSERT.h"
 

--- a/src/aquarium-optimized/Texture.h
+++ b/src/aquarium-optimized/Texture.h
@@ -50,5 +50,5 @@ class Texture
     std::string mName;
 };
 
-#endif // ! TEXTURE_H
+#endif // !TEXTURE_H
 

--- a/src/aquarium-optimized/d3d12/BufferD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/BufferD3D12.cpp
@@ -1,5 +1,4 @@
 #include "BufferD3D12.h"
-
 #include "ContextD3D12.h"
 
 BufferD3D12::BufferD3D12(ContextD3D12 *context,

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -6,10 +6,6 @@
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
 
-#include "imgui.h"
-#include "imgui_impl_dx12.h"
-#include "imgui_impl_glfw.h"
-
 #include "BufferD3D12.h"
 #include "FishModelD3D12.h"
 #include "FishModelInstancedDrawD3D12.h"
@@ -19,6 +15,10 @@
 #include "ProgramD3D12.h"
 #include "SeaweedModelD3D12.h"
 #include "TextureD3D12.h"
+
+#include "imgui.h"
+#include "imgui_impl_dx12.h"
+#include "imgui_impl_glfw.h"
 
 const CD3DX12_HEAP_PROPERTIES defaultheapProperties =
     CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -19,7 +19,7 @@ using Microsoft::WRL::ComPtr;
 
 enum BACKENDTYPE : short;
 
-const int cbvsrvCount = 87;
+constexpr int cbvsrvCount = 87;
 
 class ContextD3D12 : public Context
 {

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
@@ -5,8 +5,8 @@
 //
 // FishModelD3D12.cpp: Implements fish model of D3D12.
 
-#include "FishModelD3D12.h"
 #include "BufferD3D12.h"
+#include "FishModelD3D12.h"
 
 FishModelD3D12::FishModelD3D12(Context *context,
                                Aquarium *aquarium,
@@ -142,7 +142,7 @@ void FishModelD3D12::init()
                                               programD3D12->getFSModule(), m_pipelineState, mBlend);
 }
 
-void FishModelD3D12::preDraw() const {}
+void FishModelD3D12::prepareForDraw() const {}
 
 void FishModelD3D12::draw()
 {

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.h
@@ -11,11 +11,12 @@
 
 #include <string>
 
-#include "../FishModel.h"
 #include "BufferD3D12.h"
 #include "ContextD3D12.h"
 #include "ProgramD3D12.h"
 #include "TextureD3D12.h"
+
+#include "../FishModel.h"
 
 class FishModelD3D12 : public FishModel
 {
@@ -28,7 +29,7 @@ class FishModelD3D12 : public FishModel
     ~FishModelD3D12();
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -5,8 +5,8 @@
 //
 // FishModelD3D12.cpp: Implements fish model of D3D12.
 
-#include "FishModelInstancedDrawD3D12.h"
 #include "BufferD3D12.h"
+#include "FishModelInstancedDrawD3D12.h"
 
 FishModelInstancedDrawD3D12::FishModelInstancedDrawD3D12(Context *context,
                                                          Aquarium *aquarium,
@@ -152,7 +152,7 @@ void FishModelInstancedDrawD3D12::init()
 
 }
 
-void FishModelInstancedDrawD3D12::preDraw() const {}
+void FishModelInstancedDrawD3D12::prepareForDraw() const {}
 
 void FishModelInstancedDrawD3D12::draw()
 {

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
@@ -11,11 +11,12 @@
 
 #include <string>
 
-#include "../FishModel.h"
 #include "BufferD3D12.h"
 #include "ContextD3D12.h"
 #include "ProgramD3D12.h"
 #include "TextureD3D12.h"
+
+#include "../FishModel.h"
 
 class FishModelInstancedDrawD3D12 : public FishModel
 {
@@ -28,7 +29,7 @@ class FishModelInstancedDrawD3D12 : public FishModel
     ~FishModelInstancedDrawD3D12();
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
@@ -140,7 +140,7 @@ void GenericModelD3D12::init()
 }
 
 // Update constant buffer per frame
-void GenericModelD3D12::preDraw() const
+void GenericModelD3D12::prepareForDraw() const
 {
     CD3DX12_RANGE readRange(0, 0);
     UINT8 *m_pCbvDataBegin;

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.h
@@ -12,11 +12,12 @@
 #include <string>
 #include <vector>
 
-#include "../Model.h"
 #include "BufferD3D12.h"
 #include "ContextD3D12.h"
 #include "ProgramD3D12.h"
 #include "TextureD3D12.h"
+
+#include "../Model.h"
 
 class GenericModelD3D12 : public Model
 {
@@ -28,7 +29,7 @@ class GenericModelD3D12 : public Model
                       bool blend);
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
@@ -101,7 +101,7 @@ void InnerModelD3D12::init()
                                               programD3D12->getFSModule(), m_pipelineState, mBlend);
 }
 
-void InnerModelD3D12::preDraw() const {}
+void InnerModelD3D12::prepareForDraw() const {}
 
 void InnerModelD3D12::draw()
 {

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.h
@@ -9,11 +9,12 @@
 #ifndef INNERMODELD3D12_H
 #define INNERMODELD3D12_H 1
 
-#include "../Model.h"
 #include "BufferD3D12.h"
 #include "ContextD3D12.h"
 #include "ProgramD3D12.h"
 #include "TextureD3D12.h"
+
+#include "../Model.h"
 
 class InnerModelD3D12 : public Model
 {
@@ -25,7 +26,7 @@ class InnerModelD3D12 : public Model
                     bool blend);
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
     void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
 

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
@@ -92,7 +92,7 @@ void OutsideModelD3D12::init()
                                               programD3D12->getFSModule(), m_pipelineState, mBlend);
 }
 
-void OutsideModelD3D12::preDraw() const {}
+void OutsideModelD3D12::prepareForDraw() const {}
 
 void OutsideModelD3D12::draw()
 {

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
@@ -11,11 +11,12 @@
 
 #include <string>
 
-#include "../Model.h"
 #include "BufferD3D12.h"
 #include "ContextD3D12.h"
 #include "ProgramD3D12.h"
 #include "TextureD3D12.h"
+
+#include "../Model.h"
 
 class OutsideModelD3D12 : public Model
 {
@@ -27,7 +28,7 @@ class OutsideModelD3D12 : public Model
                       bool blend);
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
@@ -1,9 +1,8 @@
-#include "ProgramD3D12.h"
+#include <cstring>
+#include <fstream>
 
 #include "ContextD3D12.h"
-
-#include <string.h>
-#include <fstream>
+#include "ProgramD3D12.h"
 
 ProgramD3D12::ProgramD3D12(ContextD3D12 *context, std::string vId, std::string fId)
     : Program(vId, fId), vertexShader(nullptr), pixelShader(nullptr), context(context)

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.h
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.h
@@ -10,7 +10,6 @@
 #ifndef PROGRAMD3D_H
 #define PROGRAMD3D_H 1
 
-#include "../Program.h"
 
 #ifndef SHADERLOADER_H
 #define SHADERLOADER_H
@@ -18,10 +17,11 @@
 #include <string>
 #include <unordered_map>
 
-#include "../Aquarium.h"
-
 #include "stdafx.h"
-// using namespace DirectX;
+
+#include "../Aquarium.h"
+#include "../Program.h"
+
 using Microsoft::WRL::ComPtr;
 
 class ContextD3D12;

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
@@ -100,7 +100,7 @@ void SeaweedModelD3D12::init()
                                               programD3D12->getFSModule(), m_pipelineState, mBlend);
 }
 
-void SeaweedModelD3D12::preDraw() const
+void SeaweedModelD3D12::prepareForDraw() const
 {
     CD3DX12_RANGE readRangeView(0, 0);
     UINT8 *m_pCbvDataBeginView;

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
@@ -9,11 +9,12 @@
 #ifndef SEAWEEDMODELD3D12_H
 #define SEAWEEDMODELD3D12_H 1
 
-#include "../SeaweedModel.h"
 #include "BufferD3D12.h"
 #include "ContextD3D12.h"
 #include "ProgramD3D12.h"
 #include "TextureD3D12.h"
+
+#include "../SeaweedModel.h"
 
 class SeaweedModelD3D12 : public SeaweedModel
 {
@@ -25,7 +26,7 @@ class SeaweedModelD3D12 : public SeaweedModel
                       bool blend);
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/d3d12/TextureD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/TextureD3D12.cpp
@@ -1,9 +1,8 @@
-#include "TextureD3D12.h"
-
 #include <algorithm>
 #include <cmath>
 
 #include "ContextD3D12.h"
+#include "TextureD3D12.h"
 
 TextureD3D12::~TextureD3D12() {}
 

--- a/src/aquarium-optimized/d3d12/TextureD3D12.h
+++ b/src/aquarium-optimized/d3d12/TextureD3D12.h
@@ -9,13 +9,13 @@
 #ifndef TEXTURED3D12_H
 #define TEXTURED3D12_H
 
-#include "../Texture.h"
+#include <vector>
 
 #include "stdafx.h"
 
-using Microsoft::WRL::ComPtr;
+#include "../Texture.h"
 
-#include <vector>
+using Microsoft::WRL::ComPtr;
 
 class ContextD3D12;
 

--- a/src/aquarium-optimized/dawn/BufferDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferDawn.cpp
@@ -6,7 +6,6 @@
 // BufferDawn.cpp: Implements the index or vertex buffers wrappers and resource bindings of dawn.
 
 #include "BufferDawn.h"
-
 #include "ContextDawn.h"
 
 // Copy size must be a multiple of 4 bytes on dawn mac backend.

--- a/src/aquarium-optimized/dawn/BufferDawn.h
+++ b/src/aquarium-optimized/dawn/BufferDawn.h
@@ -10,9 +10,9 @@
 #define BUFFERDAWN_H 1
 
 #include <vector>
+#include <dawn/dawncpp.h>
 
 #include "../Buffer.h"
-#include <dawn/dawncpp.h>
 
 class ContextDawn;
 

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -5,16 +5,18 @@
 //
 // DeviceDawn.cpp: Implements accessing functions to the graphics API of Dawn.
 
+#include <array>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <dawn/dawn.h>
+#include <dawn/dawn_wsi.h>
+#include <dawn/dawncpp.h>
+#include <dawn_native/DawnNative.h>
+#include <shaderc/shaderc.hpp>
 
-#include "imgui.h"
-#include "imgui_impl_dawn.h"
-#include "imgui_impl_glfw.h"
-
-#include "../Aquarium.h"
 #include "BufferDawn.h"
 #include "ContextDawn.h"
 #include "FishModelDawn.h"
@@ -26,17 +28,14 @@
 #include "SeaweedModelDawn.h"
 #include "TextureDawn.h"
 
-#include <dawn/dawn.h>
-#include <dawn/dawn_wsi.h>
-#include <dawn/dawncpp.h>
-#include <dawn_native/DawnNative.h>
-#include <shaderc/shaderc.hpp>
 #include "common/Constants.h"
+#include "imgui.h"
+#include "imgui_impl_dawn.h"
+#include "imgui_impl_glfw.h"
 #include "utils/BackendBinding.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
 
-#include <array>
-#include <cstring>
+#include "../Aquarium.h"
 
 ContextDawn::ContextDawn()
     : queue(nullptr),

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -9,13 +9,13 @@
 #ifndef CONTEXTDAWN_H
 #define CONTEXTDAWN_H
 
-#include "../Context.h"
-
 #include <dawn/dawncpp.h>
 #include <dawn_native/DawnNative.h>
-#include "utils/DawnHelpers.h"
 
 #include "GLFW/glfw3.h"
+#include "utils/DawnHelpers.h"
+
+#include "../Context.h"
 
 class TextureDawn;
 class BufferDawn;

--- a/src/aquarium-optimized/dawn/FishModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelDawn.cpp
@@ -5,8 +5,8 @@
 //
 // FishModelDawn.cpp: Implements fish model of Dawn.
 
+#include "BufferDawn.h" 
 #include "FishModelDawn.h"
-#include "BufferDawn.h"
 
 FishModelDawn::FishModelDawn(const Context *context,
                              Aquarium *aquarium,
@@ -193,7 +193,7 @@ void FishModelDawn::init()
                                &fishVertexUniforms);
 }
 
-void FishModelDawn::preDraw() const {}
+void FishModelDawn::prepareForDraw() const {}
 
 void FishModelDawn::draw()
 {

--- a/src/aquarium-optimized/dawn/FishModelDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelDawn.h
@@ -9,13 +9,12 @@
 #ifndef FISHMODELDAWN_H
 #define FISHMODELDAWN_H 1
 
-#include <string>
-
-#include "../FishModel.h"
 #include "ContextDawn.h"
 #include "ProgramDawn.h"
 #include "dawn/dawncpp.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
+
+#include "../FishModel.h"
 
 class FishModelDawn : public FishModel
 {
@@ -28,7 +27,7 @@ class FishModelDawn : public FishModel
     ~FishModelDawn();
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -5,8 +5,8 @@
 //
 // FishModelDawn.cpp: Implements fish model of Dawn.
 
-#include "FishModelInstancedDrawDawn.h"
 #include "BufferDawn.h"
+#include "FishModelInstancedDrawDawn.h"
 
 FishModelInstancedDrawDawn::FishModelInstancedDrawDawn(const Context *context,
                                                        Aquarium *aquarium,
@@ -176,7 +176,7 @@ void FishModelInstancedDrawDawn::init()
                                &fishVertexUniforms);
 }
 
-void FishModelInstancedDrawDawn::preDraw() const {}
+void FishModelInstancedDrawDawn::prepareForDraw() const {}
 
 void FishModelInstancedDrawDawn::draw()
 {

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
@@ -9,13 +9,12 @@
 #ifndef FISHMODELINSTANCEDDRAWDAWN_H
 #define FISHMODELINSTANCEDDRAWDAWN_H 1
 
-#include <string>
-
-#include "../FishModel.h"
 #include "ContextDawn.h"
 #include "ProgramDawn.h"
 #include "dawn/dawncpp.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
+
+#include "../FishModel.h"
 
 class FishModelInstancedDrawDawn : public FishModel
 {
@@ -28,7 +27,7 @@ class FishModelInstancedDrawDawn : public FishModel
     ~FishModelInstancedDrawDawn();
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;

--- a/src/aquarium-optimized/dawn/GenericModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.cpp
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
+
 #include "GenericModelDawn.h"
 
 #include "../Aquarium.h"
@@ -204,7 +205,7 @@ void GenericModelDawn::init()
                                &lightFactorUniforms);
 }
 
-void GenericModelDawn::preDraw() const
+void GenericModelDawn::prepareForDraw() const
 {
     contextDawn->setBufferData(worldBuffer, 0, sizeof(WorldUniformPer), &worldUniformPer);
 }

--- a/src/aquarium-optimized/dawn/GenericModelDawn.h
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.h
@@ -9,13 +9,12 @@
 #ifndef GENERICMODELDAWN_H
 #define GENERICMODELDAWN_H 1
 
-#include <string>
-
-#include "../Model.h"
 #include "ContextDawn.h"
 #include "ProgramDawn.h"
 #include "dawn/dawncpp.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
+
+#include "../Model.h"
 
 class GenericModelDawn : public Model
 {
@@ -28,7 +27,7 @@ class GenericModelDawn : public Model
     ~GenericModelDawn();
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/dawn/InnerModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.cpp
@@ -5,8 +5,6 @@
 //
 // InnerModelDawn.cpp: Implements inner model of Dawn.
 
-#include <cstring>
-
 #include "InnerModelDawn.h"
 
 InnerModelDawn::InnerModelDawn(const Context *context,
@@ -130,7 +128,7 @@ void InnerModelDawn::init()
     contextDawn->setBufferData(innerBuffer, 0, sizeof(InnerUniforms), &innerUniforms);
 }
 
-void InnerModelDawn::preDraw() const
+void InnerModelDawn::prepareForDraw() const
 {
 }
 

--- a/src/aquarium-optimized/dawn/InnerModelDawn.h
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.h
@@ -9,11 +9,12 @@
 #ifndef INNERMODELDAWN_H
 #define INNERMODELDAWN_H 1
 
-#include "../Model.h"
 #include "ContextDawn.h"
 #include "ProgramDawn.h"
 #include "dawn/dawncpp.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
+
+#include "../Model.h"
 
 class InnerModelDawn : public Model
 {
@@ -22,7 +23,7 @@ class InnerModelDawn : public Model
     ~InnerModelDawn();
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
     void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
 

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
@@ -119,7 +119,7 @@ void OutsideModelDawn::init()
     contextDawn->setBufferData(lightFactorBuffer, 0, sizeof(LightFactorUniforms), &lightFactorUniforms);
 }
 
-void OutsideModelDawn::preDraw() const
+void OutsideModelDawn::prepareForDraw() const
 {
 }
 

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.h
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.h
@@ -9,13 +9,12 @@
 #ifndef OUTSIDEMODELDAWN_H
 #define OUTSIDEMODELDAWN_H 1
 
-#include <string>
-
-#include "../Model.h"
 #include "ContextDawn.h"
 #include "ProgramDawn.h"
 #include "dawn/dawncpp.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
+
+#include "../Model.h"
 
 class OutsideModelDawn : public Model
 {
@@ -24,7 +23,7 @@ public:
     ~OutsideModelDawn();
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/dawn/ProgramDawn.cpp
+++ b/src/aquarium-optimized/dawn/ProgramDawn.cpp
@@ -3,13 +3,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-#include "ProgramDawn.h"
+
+#include <fstream>
+#include <regex>
+#include <string>
 
 #include "ContextDawn.h"
+#include "ProgramDawn.h"
 #include "common/AQUARIUM_ASSERT.h"
-#include <fstream>
-#include <cstring>
-#include <regex>
 
 ProgramDawn::ProgramDawn(ContextDawn *context, std::string vId, std::string fId)
     : Program(vId, fId), vsModule(nullptr), fsModule(nullptr), context(context)

--- a/src/aquarium-optimized/dawn/ProgramDawn.h
+++ b/src/aquarium-optimized/dawn/ProgramDawn.h
@@ -18,9 +18,10 @@
 #include <string>
 #include <unordered_map>
 
-#include "../Aquarium.h"
 #include "BufferDawn.h"
 #include "TextureDawn.h"
+
+#include "../Aquarium.h"
 
 class ContextDawn;
 

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
@@ -107,7 +107,7 @@ void SeaweedModelDawn::init()
     contextDawn->setBufferData(lightFactorBuffer, 0, sizeof(lightFactorUniforms), &lightFactorUniforms);
 }
 
-void SeaweedModelDawn::preDraw() const
+void SeaweedModelDawn::prepareForDraw() const
 {
     contextDawn->setBufferData(viewBuffer, 0, sizeof(WorldUniformPer), &worldUniformPer);
     contextDawn->setBufferData(timeBuffer, 0, sizeof(SeaweedPer), &seaweedPer);

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.h
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.h
@@ -9,11 +9,12 @@
 #ifndef SEAWEEDMODELDAWN_H
 #define SEAWEEDMODELDAWN_H 1
 
-#include "../SeaweedModel.h"
 #include "ContextDawn.h"
 #include "ProgramDawn.h"
 #include "dawn/dawncpp.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
+
+#include "../SeaweedModel.h"
 
 class SeaweedModelDawn : public SeaweedModel
 {
@@ -22,7 +23,7 @@ class SeaweedModelDawn : public SeaweedModel
     ~SeaweedModelDawn();
 
     void init() override;
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void draw() override;
 
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;

--- a/src/aquarium-optimized/dawn/TextureDawn.cpp
+++ b/src/aquarium-optimized/dawn/TextureDawn.cpp
@@ -5,12 +5,11 @@
 //
 // TextureDawn.cpp: Wrap textures of Dawn. Load image files and wrap into a Dawn texture.
 
-#include "TextureDawn.h"
-
 #include <algorithm>
 #include <cmath>
 
 #include "ContextDawn.h"
+#include "TextureDawn.h"
 
 #include "common/AQUARIUM_ASSERT.h"
 

--- a/src/aquarium-optimized/dawn/TextureDawn.h
+++ b/src/aquarium-optimized/dawn/TextureDawn.h
@@ -9,8 +9,9 @@
 #ifndef TEXTUREDAWN_H
 #define TEXTUREDAWN_H
 
-#include "../Texture.h"
 #include <dawn/dawncpp.h>
+
+#include "../Texture.h"
 
 class ContextDawn;
 

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
@@ -1,10 +1,10 @@
 // dear imgui: Renderer for Dawn
 // This needs to be used along with a Platform Binding (e.g. GLFW)
 
+#include "ProgramDawn.h"
+
 #include "imgui_impl_dawn.h"
 #include "imgui.h"
-
-#include "ProgramDawn.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
 
 // Dawn data

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.h
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include "imgui.h"
-
 #include <dawn/dawncpp.h>
 #include <dawn_native/DawnNative.h>
+
 #include "ContextDawn.h"
+#include "imgui.h"
 #include "utils/DawnHelpers.h"
 
 IMGUI_IMPL_API bool ImGui_ImplDawn_Init(ContextDawn *context, dawn::TextureFormat rtv_format);

--- a/src/aquarium-optimized/opengl/BufferGL.h
+++ b/src/aquarium-optimized/opengl/BufferGL.h
@@ -9,7 +9,6 @@
 #ifndef BUFFERGL_H
 #define BUFFERGL_H 1
 
-#include <vector>
 #ifdef EGL_EGL_PROTOTYPES
 #include <angle_gl.h>
 #include <memory>
@@ -22,8 +21,11 @@
 #include "glad/glad.h"
 #endif
 
-#include "../Buffer.h"
+#include <vector>
+
 #include "ContextGL.h"
+
+#include "../Buffer.h"
 
 class ContextGL;
 

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -11,20 +11,19 @@
 #include <iostream>
 #include <sstream>
 
-#include "imgui.h"
-#include "imgui_impl_glfw.h"
-#include "imgui_impl_opengl3.h"
-
 #include "BufferGL.h"
 #include "ContextGL.h"
-#include "ProgramGL.h"
-#include "TextureGL.h"
-
 #include "FishModelGL.h"
 #include "GenericModelGL.h"
 #include "InnerModelGL.h"
 #include "OutsideModelGL.h"
+#include "ProgramGL.h"
 #include "SeaweedModelGL.h"
+#include "TextureGL.h"
+
+#include "imgui.h"
+#include "imgui_impl_glfw.h"
+#include "imgui_impl_opengl3.h"
 
 #ifdef EGL_EGL_PROTOTYPES
 #define GLFW_EXPOSE_NATIVE_WIN32

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -8,10 +8,6 @@
 #ifndef ContextGL_H
 #define ContextGL_H 1
 
-#include <vector>
-
-#include "../Context.h"
-
 #ifdef EGL_EGL_PROTOTYPES
 #include <angle_gl.h>
 #include "EGL/egl.h"
@@ -24,7 +20,11 @@
 #include "glad/glad.h"
 #endif
 
+#include <vector>
+
 #include "GLFW/glfw3.h"
+
+#include "../Context.h"
 
 class BufferGL;
 class TextureGL;

--- a/src/aquarium-optimized/opengl/FishModelGL.cpp
+++ b/src/aquarium-optimized/opengl/FishModelGL.cpp
@@ -102,7 +102,7 @@ void FishModelGL::draw()
     contextGL->drawElements(indicesBuffer);
 }
 
-void FishModelGL::preDraw() const
+void FishModelGL::prepareForDraw() const
 {
     mProgram->setProgram();
     contextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/FishModelGL.h
+++ b/src/aquarium-optimized/opengl/FishModelGL.h
@@ -19,7 +19,7 @@ class FishModelGL : public FishModel
 {
   public:
     FishModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
 
     void init() override;

--- a/src/aquarium-optimized/opengl/GenericModelGL.cpp
+++ b/src/aquarium-optimized/opengl/GenericModelGL.cpp
@@ -80,7 +80,7 @@ void GenericModelGL::draw()
     contextGL->drawElements(indicesBuffer);
 }
 
-void GenericModelGL::preDraw() const
+void GenericModelGL::prepareForDraw() const
 {
     mProgram->setProgram();
     contextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/GenericModelGL.h
+++ b/src/aquarium-optimized/opengl/GenericModelGL.h
@@ -9,9 +9,10 @@
 #ifndef GENERICMODELGL_H
 #define GENERICMODELGL_H 1
 
-#include "../Model.h"
 #include "ContextGL.h"
 #include "ProgramGL.h"
+
+#include "../Model.h"
 
 class GenericModelGL : public Model
 {
@@ -21,7 +22,7 @@ class GenericModelGL : public Model
                    MODELGROUP type,
                    MODELNAME name,
                    bool blend);
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
     void init() override;
     void draw() override;

--- a/src/aquarium-optimized/opengl/InnerModelGL.cpp
+++ b/src/aquarium-optimized/opengl/InnerModelGL.cpp
@@ -85,7 +85,7 @@ void InnerModelGL::draw()
     contextGL->drawElements(indicesBuffer);
 }
 
-void InnerModelGL::preDraw() const
+void InnerModelGL::prepareForDraw() const
 {
     mProgram->setProgram();
     contextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/InnerModelGL.h
+++ b/src/aquarium-optimized/opengl/InnerModelGL.h
@@ -9,15 +9,16 @@
 #ifndef INNERMODELGL_H
 #define INNERMODELGL_H 1
 
-#include "../Model.h"
 #include "ContextGL.h"
 #include "ProgramGL.h"
+
+#include "../Model.h"
 
 class InnerModelGL : public Model
 {
   public:
     InnerModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
     void init() override;
     void draw() override;

--- a/src/aquarium-optimized/opengl/OutsideModelGL.cpp
+++ b/src/aquarium-optimized/opengl/OutsideModelGL.cpp
@@ -74,7 +74,7 @@ void OutsideModelGL::draw()
     contextGL->drawElements(indicesBuffer);
 }
 
-void OutsideModelGL::preDraw() const
+void OutsideModelGL::prepareForDraw() const
 {
     mProgram->setProgram();
     contextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/OutsideModelGL.h
+++ b/src/aquarium-optimized/opengl/OutsideModelGL.h
@@ -8,6 +8,7 @@
 #pragma once
 #ifndef OutsideModelGL_H
 #define OutsideModelGL_H 1
+
 #include "ContextGL.h"
 #include "ProgramGL.h"
 
@@ -21,7 +22,7 @@ class OutsideModelGL : public Model
                    MODELGROUP type,
                    MODELNAME name,
                    bool blend);
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
     void init() override;
     void draw() override;

--- a/src/aquarium-optimized/opengl/ProgramGL.cpp
+++ b/src/aquarium-optimized/opengl/ProgramGL.cpp
@@ -8,8 +8,6 @@
 // Compiles OpenGL shaders and check if compiled success.
 // Apply Buffers, Textures and Uniforms to program.
 
-#include "ProgramGL.h"
-
 #ifdef EGL_EGL_PROTOTYPES
 #include <angle_gl.h>
 #include <memory>
@@ -21,19 +19,19 @@
 #else
 #include "glad/glad.h"
 #endif
-#include <cstdio>
-#include <string>
-#include <vector>
-#include <iostream>
+
 #include <fstream>
-#include <cstdlib>
-#include <cstring>
-#include "ProgramGL.h"
+#include <iostream>
 #include <map>
 #include <regex>
+#include <string>
+#include <vector>
+
 #include "common/AQUARIUM_ASSERT.h"
-#include "../Texture.h"
+#include "ProgramGL.h"
+
 #include "../Buffer.h"
+#include "../Texture.h"
 
 ProgramGL::ProgramGL(ContextGL *context, std::string vId, std::string fId)
     : Program(vId, fId),

--- a/src/aquarium-optimized/opengl/ProgramGL.h
+++ b/src/aquarium-optimized/opengl/ProgramGL.h
@@ -12,18 +12,18 @@
 #ifndef PROGRAMGL_H
 #define PROGRAMGL_H 1
 
-#include "../Program.h"
-
 #ifndef SHADERLOADER_H
 #define SHADERLOADER_H
 
 #include <string>
 #include <unordered_map>
 
-#include "../Aquarium.h"
 #include "BufferGL.h"
 #include "ContextGL.h"
 #include "TextureGL.h"
+
+#include "../Aquarium.h"
+#include "../Program.h"
 
 class ProgramGL : public Program
 {

--- a/src/aquarium-optimized/opengl/SeaweedModelGL.cpp
+++ b/src/aquarium-optimized/opengl/SeaweedModelGL.cpp
@@ -73,7 +73,7 @@ void SeaweedModelGL::draw()
     contextGL->drawElements(indicesBuffer);
 }
 
-void SeaweedModelGL::preDraw() const
+void SeaweedModelGL::prepareForDraw() const
 {
     mProgram->setProgram();
     contextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/SeaweedModelGL.h
+++ b/src/aquarium-optimized/opengl/SeaweedModelGL.h
@@ -9,9 +9,10 @@
 #ifndef SEAWEEDMODELGL_H
 #define SEAWEEDMODELGL_H 1
 
-#include "../SeaweedModel.h"
-#include "ProgramGL.h"
 #include "ContextGL.h"
+#include "ProgramGL.h"
+
+#include "../SeaweedModel.h"
 
 class SeaweedModelGL : public SeaweedModel
 {
@@ -21,7 +22,7 @@ class SeaweedModelGL : public SeaweedModel
                    MODELGROUP type,
                    MODELNAME name,
                    bool blend);
-    void preDraw() const override;
+    void prepareForDraw() const override;
     void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
     void init() override;
     void draw() override;

--- a/src/aquarium-optimized/opengl/TextureGL.h
+++ b/src/aquarium-optimized/opengl/TextureGL.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #ifdef EGL_EGL_PROTOTYPES
 #include <angle_gl.h>
 #include <memory>
@@ -24,8 +25,9 @@
 #include "glad/glad.h"
 #endif
 
-#include "../Texture.h"
 #include "ContextGL.h"
+
+#include "../Texture.h"
 
 class ContextGL;
 

--- a/src/common/FPSTimer.cpp
+++ b/src/common/FPSTimer.cpp
@@ -6,9 +6,8 @@
 // FPSTimer.cpp: Implement fps timer.
 
 #include "FPSTimer.h"
+
 #include <cmath>
-#include <cstdlib>
-#include <list>
 
 FPSTimer::FPSTimer()
     : mTotalTime(static_cast<float>(NUM_FRAMES_TO_AVERAGE)),


### PR DESCRIPTION
This patch does some code clean up.
1. Fix typo 'shders' -> 'shaders'
2. Rename preDraw() and drawPre() to prepareForDraw()
3. Clean up redundant includes and sort include files in alphabet order