### PR TITLE
Fix imgui when enable msaa on Dawn

### DIFF
--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -229,7 +229,7 @@ bool ContextDawn::initialize(
     // Because imgui doesn't have dawn backend, we rewrite the functions by dawn API in
     // imgui_impl_dawn.cpp and imgui_impl_dawn.h
     ImGui_ImplGlfw_InitForOpenGL(mWindow, true);
-    ImGui_ImplDawn_Init(this, mPreferredSwapChainFormat);
+    ImGui_ImplDawn_Init(this, mPreferredSwapChainFormat, mEnableMSAA);
 
     return true;
 }

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
@@ -28,6 +28,7 @@ ContextDawn *contextDawn(nullptr);
 
 int mIndexBufferSize  = 0;
 int mVertexBufferSize = 0;
+bool mEnableMSAA      = false;
 ImDrawVert vertexData[3000];
 ImDrawIdx indexData[3000];
 
@@ -313,7 +314,7 @@ bool ImGui_ImplDawn_CreateDeviceObjects()
     pipelineDescriptor.cDepthStencilState.depthWriteEnabled = false;
     pipelineDescriptor.cDepthStencilState.depthCompare      = dawn::CompareFunction::Always;
     pipelineDescriptor.primitiveTopology                    = dawn::PrimitiveTopology::TriangleList;
-    pipelineDescriptor.sampleCount                          = 1;
+    pipelineDescriptor.sampleCount                          = mEnableMSAA ? 4 : 1;
     pipelineDescriptor.rasterizationState                   = &rasterizationState;
 
     mPipeline = mDevice.CreateRenderPipeline(&pipelineDescriptor);
@@ -336,7 +337,7 @@ bool ImGui_ImplDawn_CreateDeviceObjects()
     return true;
 }
 
-bool ImGui_ImplDawn_Init(ContextDawn *context, dawn::TextureFormat rtv_format)
+bool ImGui_ImplDawn_Init(ContextDawn *context, dawn::TextureFormat rtv_format, bool enableMSAA)
 {
     // Setup back-end capabilities flags
     ImGuiIO &io            = ImGui::GetIO();
@@ -353,6 +354,7 @@ bool ImGui_ImplDawn_Init(ContextDawn *context, dawn::TextureFormat rtv_format)
     mVertexBuffer     = NULL;
     mIndexBufferSize  = 10000;
     mVertexBufferSize = 5000;
+    mEnableMSAA       = enableMSAA;
 
     return true;
 }

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.h
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.h
@@ -10,7 +10,9 @@
 #include "imgui.h"
 #include "utils/DawnHelpers.h"
 
-IMGUI_IMPL_API bool ImGui_ImplDawn_Init(ContextDawn *context, dawn::TextureFormat rtv_format);
+IMGUI_IMPL_API bool ImGui_ImplDawn_Init(ContextDawn *context,
+                                        dawn::TextureFormat rtv_format,
+                                        bool enableMSAA);
 IMGUI_IMPL_API void ImGui_ImplDawn_Shutdown();
 IMGUI_IMPL_API void ImGui_ImplDawn_NewFrame();
 IMGUI_IMPL_API void ImGui_ImplDawn_RenderDrawData(ImDrawData *draw_data);


### PR DESCRIPTION
The app cannot work if some pipelines are MSAA but some are not.
This may be a bug in dawn. PTAL. Thanks.

@Jiawei-Shao @shaoboyan @qjia7