### PR TITLE
More code clean up

### DIFF
--- a/src/aquarium-direct-map/AttribBuffer.cpp
+++ b/src/aquarium-direct-map/AttribBuffer.cpp
@@ -10,7 +10,7 @@
 AttribBuffer::AttribBuffer(int numComponents,
                            const std::vector<float> &buffer,
                            int size,
-                           std::string opt_type)
+                           const std::string &opt_type)
     : type(opt_type),
     bufferFloat(buffer),
     bufferUShort(),
@@ -22,7 +22,7 @@ AttribBuffer::AttribBuffer(int numComponents,
 AttribBuffer::AttribBuffer(int numComponents,
                            const std::vector<unsigned short> &buffer,
                            int size,
-                           std::string opt_type)
+                           const std::string &opt_type)
     : type(opt_type),
     bufferFloat(),
     bufferUShort(buffer),

--- a/src/aquarium-direct-map/AttribBuffer.h
+++ b/src/aquarium-direct-map/AttribBuffer.h
@@ -15,18 +15,18 @@ class AttribBuffer
 {
 public:
   AttribBuffer() {}
-  AttribBuffer(int numComponents, const std::vector<float> &buffer, int size, std::string opt_type);
+  AttribBuffer(int numComponents, const std::vector<float> &buffer, int size, const std::string &opt_type);
   AttribBuffer(int numComponents,
                const std::vector<unsigned short> &buffer,
                int size,
-               std::string opt_type);
+               const std::string &opt_type);
 
-  int getNumComponents() { return numComponents; }
-  int getNumElements() { return numElements; }
+  int getNumComponents() const { return numComponents; }
+  int getNumElements() const { return numElements; }
 
-  std::vector<float> *getBufferFloat() { return &bufferFloat; }
-  std::vector<unsigned short> *getBufferUShort() { return &bufferUShort; }
-  std::string getType() { return type; }
+  const std::vector<float> &getBufferFloat() const { return bufferFloat; }
+  const std::vector<unsigned short> &getBufferUShort() const { return bufferUShort; }
+  const std::string &getType() const { return type; }
 
 private:
   std::string type;

--- a/src/aquarium-direct-map/Buffer.cpp
+++ b/src/aquarium-direct-map/Buffer.cpp
@@ -11,10 +11,10 @@
 
 #include "common/AQUARIUM_ASSERT.h"
 
-Buffer::Buffer(AttribBuffer *attribBuffer, GLenum target)
+Buffer::Buffer(const AttribBuffer &attribBuffer, GLenum target)
     : mBuf(0),
-      mNumComponents(attribBuffer->getNumComponents()),
-      mNumElements(attribBuffer->getNumElements()),
+      mNumComponents(attribBuffer.getNumComponents()),
+      mNumElements(attribBuffer.getNumElements()),
       mTotalComponents(0),
       mType(0),
       mNormalize(true),
@@ -28,20 +28,20 @@ Buffer::Buffer(AttribBuffer *attribBuffer, GLenum target)
 
     mTotalComponents = mNumComponents * mNumElements;
 
-    auto bufferFloat  = attribBuffer->getBufferFloat();
-    auto bufferUShort = attribBuffer->getBufferUShort();
+    auto bufferFloat  = attribBuffer.getBufferFloat();
+    auto bufferUShort = attribBuffer.getBufferUShort();
 
-    if (attribBuffer->getType() == "Float32Array")
+    if (attribBuffer.getType() == "Float32Array")
     {
         mType      = GL_FLOAT;
         mNormalize = false;
-        glBufferData(target, sizeof(GLfloat) * bufferFloat->size(), bufferFloat->data(),
+        glBufferData(target, sizeof(GLfloat) * bufferFloat.size(), bufferFloat.data(),
                      GL_STATIC_DRAW);
     }
-    else if (attribBuffer->getType() == "Uint16Array")
+    else if (attribBuffer.getType() == "Uint16Array")
     {
         mType = GL_UNSIGNED_SHORT;
-        glBufferData(target, sizeof(GLushort) * bufferUShort->size(), bufferUShort->data(),
+        glBufferData(target, sizeof(GLushort) * bufferUShort.size(), bufferUShort.data(),
                      GL_STATIC_DRAW);
     }
     else

--- a/src/aquarium-direct-map/Buffer.h
+++ b/src/aquarium-direct-map/Buffer.h
@@ -17,7 +17,7 @@ class Buffer
 {
 public:
   Buffer() {}
-  Buffer(AttribBuffer *array, GLenum target);
+  Buffer(const AttribBuffer &array, GLenum target);
   ~Buffer();
 
   GLuint getBuffer() const { return mBuf; }

--- a/src/aquarium-direct-map/Main.cpp
+++ b/src/aquarium-direct-map/Main.cpp
@@ -109,22 +109,22 @@ Fish g_fishTable[] = { { "SmallFishA", 1.0f, 1.5f, 30.0f, 25.0f, 10.0f, 0.0f, 16
 { "BigFishA", 0.5f, 0.5f, 50.0f, 3.0f, 1.5f, 0.0f, 16.0f,{ 10.0f, -1.0f, 0.5f }, true, 0.04f,{ 0.0f, 0.1f, 9.0f },{ 0.3f, 0.3f, 1000.0f } },
 { "BigFishB", 0.5f, 0.5f, 45.0f, 3.0f, 1.0f, 0.0f, 16.0f,{ 10.0f, -0.7f, 0.3f }, true, 0.04f,{ 0.0f, -0.3f, 9.0f },{ 0.3f, 0.3f, 1000.0f } } };
 
-void setGenericConstMatrix(GenericConst& genericConst) {
-    genericConst.viewProjection = &viewProjection;
-    genericConst.viewInverse    = &viewInverse;
-    genericConst.lightWorldPos  = &lightWorldPos;
-    genericConst.lightColor     = &lightColor;
-    genericConst.specular       = &specular;
-    genericConst.ambient        = &ambient;
-    genericConst.fogColor       = &fogColor;
+void setGenericConstMatrix(GenericConst *genericConst) {
+    genericConst->viewProjection = &viewProjection;
+    genericConst->viewInverse    = &viewInverse;
+    genericConst->lightWorldPos  = &lightWorldPos;
+    genericConst->lightColor     = &lightColor;
+    genericConst->specular       = &specular;
+    genericConst->ambient        = &ambient;
+    genericConst->fogColor       = &fogColor;
 }
 
-void setGenericPer(GenericPer& genericPer)
+void setGenericPer(GenericPer *genericPer)
 {
-    genericPer.world                 = &world;
-    genericPer.worldViewProjection   = &worldViewProjection;
-    genericPer.worldInverse          = &worldInverse;
-    genericPer.worldInverseTranspose = &worldInverseTraspose;
+    genericPer->world                 = &world;
+    genericPer->worldViewProjection  = &worldViewProjection;
+    genericPer->worldInverse          = &worldInverse;
+    genericPer->worldInverseTranspose = &worldInverseTraspose;
 }
 
 void initializeUniforms() {
@@ -149,18 +149,18 @@ void initializeUniforms() {
     fishConst.genericConst.shininess      = fish_shininess;
     fishConst.genericConst.specularFactor = fish_specularFactor;
 
-    setGenericConstMatrix(sandConst);
-    setGenericConstMatrix(genericConst);
-    setGenericConstMatrix(seaweedConst);
-    setGenericConstMatrix(innerConst);
-    setGenericConstMatrix(outsideConst);
-    setGenericConstMatrix(fishConst.genericConst);
-    setGenericPer(sandPer);
-    setGenericPer(genericPer);
-    setGenericPer(seaweedPer);
-    setGenericPer(innerPer);
-    setGenericPer(outsidePer);
-    setGenericPer(laserPer);
+    setGenericConstMatrix(&sandConst);
+    setGenericConstMatrix(&genericConst);
+    setGenericConstMatrix(&seaweedConst);
+    setGenericConstMatrix(&innerConst);
+    setGenericConstMatrix(&outsideConst);
+    setGenericConstMatrix(&fishConst.genericConst);
+    setGenericPer(&sandPer);
+    setGenericPer(&genericPer);
+    setGenericPer(&seaweedPer);
+    setGenericPer(&innerPer);
+    setGenericPer(&outsidePer);
+    setGenericPer(&laserPer);
 
     skyConst.viewProjectionInverse = &viewProjectionInverse;
 
@@ -221,7 +221,7 @@ void LoadPlacement()
         }
 }
 
-Scene *loadScene(const std::string &name, std::string *opt_programIds)
+Scene *loadScene(const std::string &name, const std::string opt_programIds[2])
 {
     Scene *scene = new Scene(opt_programIds);
     scene->load(mPath, name);
@@ -438,9 +438,9 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-void DrawGroup(std::multimap<std::string, std::vector<float>> &group,
-               GenericConst &constUniforms,
-               GenericPer &perUniforms)
+void DrawGroup(const std::multimap<std::string, std::vector<float>> &group,
+               const GenericConst &constUniforms,
+               GenericPer *perUniforms)
 {
     Model *currentModel = nullptr;
     int ii              = 0;
@@ -475,8 +475,8 @@ void DrawGroup(std::multimap<std::string, std::vector<float>> &group,
             matrix::mulMatrixMatrix4(worldViewProjection, world, viewProjection);
             matrix::inverse4(worldInverse, world);
             matrix::transpose4(worldInverseTraspose, worldInverse);
-            perUniforms.time = mClock + (ii++);
-            model->draw(perUniforms);
+            perUniforms->time = mClock + (ii++);
+            model->draw(*perUniforms);
         }
     }
 }
@@ -586,7 +586,7 @@ void render() {
     // Draw Scene
     if (g_sceneGroups.find("base") != g_sceneGroups.end())
     {
-        DrawGroup(g_sceneGroups["base"], genericConst, genericPer);
+        DrawGroup(g_sceneGroups["base"], genericConst, &genericPer);
     }
 
     // Draw Fishes
@@ -652,18 +652,18 @@ void render() {
     // Draw tank
     if (g_sceneGroups.find("inner") != g_sceneGroups.end())
     {
-        DrawGroup(g_sceneGroups["inner"], innerConst, innerPer);
+        DrawGroup(g_sceneGroups["inner"], innerConst, &innerPer);
     }
 
     // Draw seaweed
     if (g_sceneGroups.find("seaweed") != g_sceneGroups.end())
     {
-        DrawGroup(g_sceneGroups["seaweed"], seaweedConst, seaweedPer);
+        DrawGroup(g_sceneGroups["seaweed"], seaweedConst, &seaweedPer);
     }
 
     // Draw outside
     if (g_sceneGroups.find("outside") != g_sceneGroups.end())
     {
-        DrawGroup(g_sceneGroups["outside"], outsideConst, outsidePer);
+        DrawGroup(g_sceneGroups["outside"], outsideConst, &outsidePer);
     }
 }

--- a/src/aquarium-direct-map/Model.cpp
+++ b/src/aquarium-direct-map/Model.cpp
@@ -12,8 +12,8 @@
 #include "common/AQUARIUM_ASSERT.h"
 
 Model::Model(Program *program_,
-             std::unordered_map<std::string, AttribBuffer *> *arrays,
-             std::unordered_map<std::string, Texture *> *textures)
+             const std::unordered_map<std::string, const AttribBuffer *> &arrays,
+             const std::unordered_map<std::string, Texture *> *textures)
     : buffers(),
     textures(textures),
     program(program_),
@@ -26,30 +26,28 @@ Model::Model(Program *program_,
 
 Model::~Model()
 {
-    for (auto buffer : buffers)
+    for (auto &buffer : buffers)
     {
         delete buffer.second;
         buffer.second = nullptr;
     }
 }
 
-void Model::setBuffer(const std::string &name, AttribBuffer *array)
+void Model::setBuffer(const std::string &name, const AttribBuffer &array)
 {
     GLenum target = name == "indices" ? GL_ELEMENT_ARRAY_BUFFER : GL_ARRAY_BUFFER;
 
     if (buffers.find(name) == buffers.end())
     {
-        Buffer *b = new Buffer(array, target);
-        buffers[name] = b;
+        buffers[name] = new Buffer(array, target);
     }
 }
 
-void Model::setBuffers(std::unordered_map<std::string, AttribBuffer *> *arrays)
+void Model::setBuffers(const std::unordered_map<std::string, const AttribBuffer *> &arrays)
 {
-    for (std::unordered_map<std::string, AttribBuffer *>::iterator iter = arrays->begin();
-         iter != arrays->end(); ++iter)
+    for (auto iter = arrays.cbegin(); iter != arrays.cend(); ++iter)
     {
-        setBuffer(iter->first, iter->second);
+        setBuffer(iter->first, *iter->second);
     }
 }
 
@@ -82,10 +80,9 @@ void Model::applyBuffers() const
 void Model::applyTextures() const
 {
     // Apply textures
-    for (std::unordered_map<std::string, Texture *>::iterator it = textures->begin();
-         it != textures->end(); ++it)
+    for (auto it = textures->cbegin(); it != textures->cend(); ++it)
     {
-        program->setUniform(it->first, it->second);
+        program->setUniform(it->first, *it->second);
     }
 }
 
@@ -97,18 +94,18 @@ void Model::prepareForDraw(const GenericConst &constUniforms)
     applyTextures();
 
     // Apply other uniforms
-    program->setUniform("ambient", constUniforms.ambient);
-    program->setUniform("fogColor", constUniforms.fogColor);
+    program->setUniform("ambient", *constUniforms.ambient);
+    program->setUniform("fogColor", *constUniforms.fogColor);
     program->setUniform("fogMult", constUniforms.fogMult);
     program->setUniform("fogOffset", constUniforms.fogOffset);
     program->setUniform("fogPower", constUniforms.fogPower);
-    program->setUniform("lightColor", constUniforms.lightColor);
+    program->setUniform("lightColor", *constUniforms.lightColor);
     program->setUniform("shininess", constUniforms.shininess);
-    program->setUniform("specular", constUniforms.specular);
+    program->setUniform("specular", *constUniforms.specular);
     program->setUniform("specularFactor", constUniforms.specularFactor);
-    program->setUniform("lightWorldPos", constUniforms.lightWorldPos);
-    program->setUniform("viewInverse", constUniforms.viewInverse);
-    program->setUniform("viewProjection", constUniforms.viewProjection);
+    program->setUniform("lightWorldPos", *constUniforms.lightWorldPos);
+    program->setUniform("viewInverse", *constUniforms.viewInverse);
+    program->setUniform("viewProjection", *constUniforms.viewProjection);
 
     // The belowing uniforms belongs to innerConst
     program->setUniform("eta", constUniforms.eta);
@@ -144,10 +141,10 @@ void Model::drawFunc()
 
 void Model::draw(const GenericPer &perUniforms)
 {
-    program->setUniform("world", perUniforms.world);
-    program->setUniform("worldInverse", perUniforms.worldInverse);
-    program->setUniform("worldInverseTranspose", perUniforms.worldInverseTranspose);
-    program->setUniform("worldViewProjection", perUniforms.worldViewProjection);
+    program->setUniform("world", *perUniforms.world);
+    program->setUniform("worldInverse", *perUniforms.worldInverse);
+    program->setUniform("worldInverseTranspose", *perUniforms.worldInverseTranspose);
+    program->setUniform("worldViewProjection", *perUniforms.worldViewProjection);
 
     drawFunc();
     ASSERT(glGetError() == GL_NO_ERROR);
@@ -155,8 +152,8 @@ void Model::draw(const GenericPer &perUniforms)
 
 void Model::draw(const FishPer &fishPer)
 {
-    program->setUniform("worldPosition", &fishPer.worldPosition);
-    program->setUniform("nextPosition", &fishPer.nextPosition);
+    program->setUniform("worldPosition", fishPer.worldPosition);
+    program->setUniform("nextPosition", fishPer.nextPosition);
     program->setUniform("scale", fishPer.scale);
     program->setUniform("time", fishPer.time);
 

--- a/src/aquarium-direct-map/Model.h
+++ b/src/aquarium-direct-map/Model.h
@@ -27,8 +27,8 @@ public:
   Model() {}
   ~Model();
   Model(Program *program,
-        std::unordered_map<std::string, AttribBuffer *> *arrays,
-        std::unordered_map<std::string, Texture *> *textures);
+        const std::unordered_map<std::string, const AttribBuffer *> &arrays,
+        const std::unordered_map<std::string, Texture *> *textures);
 
   void prepareForDraw(const GenericConst &constUniforms);
   void prepareForDraw(const FishConst &fishConst);
@@ -36,14 +36,14 @@ public:
   void draw(const FishPer &fishPer);
 
 private:
-  void setBuffers(std::unordered_map<std::string, AttribBuffer *> *arrays);
-  void setBuffer(const std::string &name, AttribBuffer *array);
+  void setBuffers(const std::unordered_map<std::string, const AttribBuffer *> &arrays);
+  void setBuffer(const std::string &name, const AttribBuffer &array);
   void applyBuffers() const;
   void applyTextures() const;
   void drawFunc();
 
   std::unordered_map<std::string, Buffer *> buffers;
-  std::unordered_map<std::string, Texture *> *textures;
+  const std::unordered_map<std::string, Texture *> *textures;
   Program *program;
 
   GLenum mode;

--- a/src/aquarium-direct-map/Program.cpp
+++ b/src/aquarium-direct-map/Program.cpp
@@ -17,7 +17,7 @@
 
 #include "common/AQUARIUM_ASSERT.h"
 
-Program::Program(std::string vId, std::string fId)
+Program::Program(const std::string &vId, const std::string &fId)
     : program(0u),
     attribLocs(),
     uniforms(),
@@ -206,7 +206,7 @@ void Program::setUniform(const std::string &name, float v)
     ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-void Program::setUniform(const std::string &name, const std::vector<float> *v)
+void Program::setUniform(const std::string &name, const std::vector<float> &v)
 {
     if (uniforms.find(name) == uniforms.end())
     {
@@ -221,22 +221,22 @@ void Program::setUniform(const std::string &name, const std::vector<float> *v)
     {
         case GL_FLOAT_VEC4:
         {
-            glUniform4fv(loc, 1, v->data());
+            glUniform4fv(loc, 1, v.data());
             break;
         }
         case GL_FLOAT_VEC3:
         {
-            glUniform3fv(loc, 1, v->data());
+            glUniform3fv(loc, 1, v.data());
             break;
         }
         case GL_FLOAT_VEC2:
         {
-            glUniform2fv(loc, 1, v->data());
+            glUniform2fv(loc, 1, v.data());
             break;
         }
         case GL_FLOAT_MAT4:
         {
-            glUniformMatrix4fv(loc, 1, false, v->data());
+            glUniformMatrix4fv(loc, 1, false, v.data());
             break;
         }
         default:
@@ -248,7 +248,7 @@ void Program::setUniform(const std::string &name, const std::vector<float> *v)
     ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-void Program::setUniform(const std::string &name, const Texture *texture)
+void Program::setUniform(const std::string &name, const Texture &texture)
 {
     if (uniforms.find(name) == uniforms.end())
     {
@@ -262,7 +262,7 @@ void Program::setUniform(const std::string &name, const Texture *texture)
     glUniform1i(loc, textureUnits[name]);
     glActiveTexture(GL_TEXTURE0 + textureUnits[name]);
     ASSERT(textureUnits[name] < 16);
-    glBindTexture(texture->getTarget(), texture->getTexture());
+    glBindTexture(texture.getTarget(), texture.getTexture());
 
     ASSERT(glGetError() == GL_NO_ERROR);
 }

--- a/src/aquarium-direct-map/Program.h
+++ b/src/aquarium-direct-map/Program.h
@@ -20,12 +20,12 @@ class Program
 {
 public:
   Program() {}
-  Program(std::string vId, std::string fId);
+  Program(const std::string &vId, const std::string &fId);
   ~Program();
   void use();
   void setUniform(const std::string &name, float v);
-  void setUniform(const std::string &name, const std::vector<float> *v);
-  void setUniform(const std::string &name, const Texture *texture);
+  void setUniform(const std::string &name, const std::vector<float> &v);
+  void setUniform(const std::string &name, const Texture &texture);
 
   const std::unordered_map<std::string, GLint> &getAttribLocs() const { return attribLocs; }
   const std::unordered_map<std::string, Uniform *> &getUniforms() const { return uniforms; }

--- a/src/aquarium-direct-map/Scene.cpp
+++ b/src/aquarium-direct-map/Scene.cpp
@@ -11,11 +11,11 @@
 #include <iostream>
 #include <sstream>
 
-#include "common/AQUARIUM_ASSERT.h"
 #include "Globals.h"
 #include "Model.h"
 #include "Program.h"
 #include "Scene.h"
+#include "common/AQUARIUM_ASSERT.h"
 
 #include "rapidjson/document.h"
 #include "rapidjson/filereadstream.h"
@@ -24,11 +24,12 @@
 
 std::vector<std::string> g_skyBoxUrls = {
     "GlobeOuter_EM_positive_x.jpg", "GlobeOuter_EM_negative_x.jpg", "GlobeOuter_EM_positive_y.jpg",
-    "GlobeOuter_EM_negative_y.jpg", "GlobeOuter_EM_positive_z.jpg", "GlobeOuter_EM_negative_z.jpg" };
+    "GlobeOuter_EM_negative_y.jpg", "GlobeOuter_EM_positive_z.jpg", "GlobeOuter_EM_negative_z.jpg"};
 
-Scene::Scene(std::string *opt_programIds)
-    : programIds(opt_programIds), url(), models(), textureMap(), arrayMap()
+Scene::Scene(const std::string opt_programIds[2]) : url(), models(), textureMap(), arrayMap()
 {
+    programIds[0] = opt_programIds[0];
+    programIds[1] = opt_programIds[1];
 }
 
 Scene::~Scene()
@@ -215,7 +216,7 @@ void Scene::load(const std::string &path, const std::string &name)
             g_programMap[vsId + fsId] = program;
         }
 
-        Model *model = new Model(program, &arrayMap, &textureMap);
+        Model *model = new Model(program, arrayMap, &textureMap);
         models.push_back(model);
     }
 }

--- a/src/aquarium-direct-map/Scene.h
+++ b/src/aquarium-direct-map/Scene.h
@@ -21,7 +21,7 @@ class Scene {
 public:
   Scene() {}
   ~Scene();
-  Scene(std::string *opt_programIds);
+  Scene(const std::string opt_programIds[2]);
 
   void load(const std::string &path, const std::string &name);
   const std::vector<Model *> &getModels() const { return models; }
@@ -31,11 +31,11 @@ public:
 private:
   void setupSkybox(const std::string &path);
 
-  std::string *programIds;
+  std::string programIds[2];
   std::string url;
   std::vector<Model *> models;
   std::unordered_map<std::string, Texture *> textureMap;
-  std::unordered_map<std::string, AttribBuffer *> arrayMap;
+  std::unordered_map<std::string, const AttribBuffer *> arrayMap;
 };
 
 #endif // !SCENE_H

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -443,6 +443,23 @@ class Aquarium
 
   private:
     void render();
+    void loadReource();
+    void loadPlacement();
+    void loadModels();
+    void loadModel(const G_sceneInfo &info);
+    void setupModelEnumMap();
+    void calculateFishCount();
+    void updateWorldMatrixAndDraw(Model *model);
+    void updateGlobalUniforms();
+    void drawBackground();
+    void drawFishes();
+    void drawSeaweed();
+    void drawInner();
+    void drawOutside();
+    void updateWorldProjections(const std::vector<float> &w);
+    BACKENDTYPE getBackendType(const std::string &backendPath);
+    float getElapsedTime();
+
     std::unordered_map<std::string, MODELNAME> mModelEnumMap;
     std::unordered_map<std::string, Texture *> mTextureMap;
     std::unordered_map<std::string, Program *> mProgramMap;
@@ -453,24 +470,6 @@ class Aquarium
     BACKENDTYPE mBackendType;
     ContextFactory *factory;
     std::vector<std::string> skyUrls;
-
-    void loadReource();
-    void loadPlacement();
-    void loadModels();
-    void loadModel(const G_sceneInfo &info);
-    void setupModelEnumMap();
-    void calculateFishCount();
-    float degToRad(float degrees);
-    void updateWorldMatrixAndDraw(Model *model);
-    void updateGlobalUniforms();
-    void drawBackground();
-    void drawFishes();
-    void drawSeaweed();
-    void drawInner();
-    void drawOutside();
-    void updateWorldProjections(const float *world);
-    BACKENDTYPE getBackendType(std::string &backendPath);
-    float getElapsedTime();
 };
 
 #endif

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -39,13 +39,14 @@ class Context
     virtual bool initialize(
         BACKENDTYPE backend,
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)              = 0;
-    virtual Texture *createTexture(std::string name, std::string url)                         = 0;
-    virtual Texture *createTexture(std::string name, const std::vector<std::string> &urls)    = 0;
-    virtual Buffer *createBuffer(int numComponents, std::vector<float> &buffer, bool isIndex) = 0;
+    virtual Texture *createTexture(const std::string &name, const std::string &url)           = 0;
+    virtual Texture *createTexture(const std::string &name,
+                                   const std::vector<std::string> &urls)                      = 0;
+    virtual Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) = 0;
     virtual Buffer *createBuffer(int numComponents,
-                                 std::vector<unsigned short> &buffer,
+                                 std::vector<unsigned short> *buffer,
                                  bool isIndex)                                                = 0;
-    virtual Program *createProgram(std::string vId, std::string fId)                          = 0;
+    virtual Program *createProgram(const std::string &vId, const std::string &fId)            = 0;
     virtual void setWindowTitle(const std::string &text)                                      = 0;
     virtual bool ShouldQuit()                                                                 = 0;
     virtual void KeyBoardQuit()                                                               = 0;

--- a/src/aquarium-optimized/Matrix.h
+++ b/src/aquarium-optimized/Matrix.h
@@ -374,5 +374,10 @@ void translate(float *m, const float *v)
     m[14] = m02 * v0 + m12 * v1 + m22 * v2 + m32;
     m[15] = m03 * v0 + m13 * v1 + m23 * v2 + m33;
 }
+
+float degToRad(float degrees)
+{
+    return static_cast<float>(degrees * M_PI / 180.0);
+}
 }
 #endif

--- a/src/aquarium-optimized/Model.cpp
+++ b/src/aquarium-optimized/Model.cpp
@@ -18,7 +18,7 @@ Model::Model()
 
 Model::~Model()
 {
-    for (auto buf : bufferMap)
+    for (auto &buf : bufferMap)
     {
         if (buf.second != nullptr)
         {

--- a/src/aquarium-optimized/Model.h
+++ b/src/aquarium-optimized/Model.h
@@ -34,7 +34,7 @@ class Model
         : mProgram(nullptr), mBlend(blend), mName(name) {}
     virtual ~Model();
     virtual void prepareForDraw() const     = 0;
-    virtual void updatePerInstanceUniforms(WorldUniforms* worldUniforms) = 0;
+    virtual void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) = 0;
     virtual void draw() = 0;
 
     void setProgram(Program *program);

--- a/src/aquarium-optimized/Program.h
+++ b/src/aquarium-optimized/Program.h
@@ -16,7 +16,7 @@ class Program
 {
   public:
     Program(){}
-    Program(std::string vertexShader, std::string fragmentShader)
+    Program(const std::string &vertexShader, const std::string &fragmentShader)
         : vId(vertexShader), fId(fragmentShader)
     {
     }

--- a/src/aquarium-optimized/Texture.cpp
+++ b/src/aquarium-optimized/Texture.cpp
@@ -18,7 +18,7 @@
 #include "stb_image.h"
 #include "stb_image_resize.h"
 
-Texture::Texture(std::string name, const std::string &url, bool flip)
+Texture::Texture(const std::string &name, const std::string &url, bool flip)
     : mUrls(),
     mWidth(0),
     mHeight(0),

--- a/src/aquarium-optimized/Texture.h
+++ b/src/aquarium-optimized/Texture.h
@@ -17,8 +17,8 @@ class Texture
   public:
     virtual ~Texture(){}
     Texture() {}
-    Texture(std::string name, const std::vector<std::string> &urls, bool flip) : mUrls(urls), mFlip(flip), mName(name) {}
-    Texture(std::string name, const std::string &url, bool flip);
+    Texture(const std::string &name, const std::vector<std::string> &urls, bool flip) : mUrls(urls), mFlip(flip), mName(name) {}
+    Texture(const std::string &name, const std::string &url, bool flip);
     std::string getName() { return mName; }
     virtual void loadTexture() = 0;
     void generateMipmap(uint8_t *input_pixels,

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -42,24 +42,24 @@ class ContextD3D12 : public Context
     void preFrame() override;
 
     Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
-    Buffer *createBuffer(int numComponents, std::vector<float> &buffer, bool isIndex) override;
+    Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) override;
     Buffer *createBuffer(int numComponents,
-                         std::vector<unsigned short> &buffer,
+                         std::vector<unsigned short> *buffer,
                          bool isIndex) override;
 
-    Program *createProgram(std::string vId, std::string fId) override;
+    Program *createProgram(const std::string &vId, const std::string &fId) override;
 
-    Texture *createTexture(std::string name, std::string url) override;
-    Texture *createTexture(std::string name, const std::vector<std::string> &urls) override;
+    Texture *createTexture(const std::string &name, const std::string &url) override;
+    Texture *createTexture(const std::string &name, const std::vector<std::string> &urls) override;
 
     void initGeneralResources(Aquarium *aquarium) override;
     void updateWorldlUniforms(Aquarium *aquarium) override;
 
     ComPtr<ID3DBlob> createShaderModule(const std::string &type, const std::string &shader);
     void createCommittedResource(const D3D12_HEAP_PROPERTIES &properties,
-                                 const D3D12_RESOURCE_DESC &textureDesc,
+                                 const D3D12_RESOURCE_DESC &desc,
                                  D3D12_RESOURCE_STATES state,
-                                 ComPtr<ID3D12Resource> &);
+                                 ComPtr<ID3D12Resource> &resource);
     void updateSubresources(ID3D12GraphicsCommandList *pCmdList,
                             ID3D12Resource *pDestinationResource,
                             ID3D12Resource *pIntermediate,
@@ -67,9 +67,6 @@ class ContextD3D12 : public Context
                             UINT FirstSubresource,
                             UINT NumSubresources,
                             D3D12_SUBRESOURCE_DATA *pSrcData);
-    void createShaderResourceView(ID3D12Resource *pResource,
-                                  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
-                                  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
     void executeCommandLists(UINT NumCommandLists, ID3D12CommandList *const *ppCommandLists);
 
     void createCommandList(ID3D12PipelineState *pInitialState,
@@ -79,7 +76,7 @@ class ContextD3D12 : public Context
                                                UINT64 byteSize,
                                                ComPtr<ID3D12Resource> &uploadBuffer) const;
     ComPtr<ID3D12Resource> createUploadBuffer(const void *initData, UINT64 byteSize) const;
-    void createRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *pRootSignatureDesc,
+    void createRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &pRootSignatureDesc,
                              ComPtr<ID3D12RootSignature> &m_rootSignature) const;
     void createGraphicsPipelineState(const std::vector<D3D12_INPUT_ELEMENT_DESC> &inputElementDescs,
                                      const ComPtr<ID3D12RootSignature> &rootSignature,
@@ -87,17 +84,16 @@ class ContextD3D12 : public Context
                                      const ComPtr<ID3DBlob> &pixelShader,
                                      ComPtr<ID3D12PipelineState> &pipelineState,
                                      bool enableBlend) const;
-    void createSampler(D3D12_SAMPLER_DESC *pDesc, ComPtr<ID3D12DescriptorHeap> &samplerHeap) const;
     void buildSrvDescriptor(const ComPtr<ID3D12Resource> &resource,
                             const D3D12_SHADER_RESOURCE_VIEW_DESC &srvDesc,
-                            OUT D3D12_GPU_DESCRIPTOR_HANDLE *hGpuDescriptor);
+                            D3D12_GPU_DESCRIPTOR_HANDLE *hGpuDescriptor);
     void buildCbvDescriptor(const D3D12_CONSTANT_BUFFER_VIEW_DESC &cbvDesc,
-                            OUT D3D12_GPU_DESCRIPTOR_HANDLE *hGpuDescriptor);
+                            D3D12_GPU_DESCRIPTOR_HANDLE *hGpuDescriptor);
     UINT CalcConstantBufferByteSize(UINT byteSize);
     void createTexture(const D3D12_RESOURCE_DESC &textureDesc,
-                       OUT ComPtr<ID3D12Resource> &m_texture,
-                       OUT ComPtr<ID3D12Resource> &textureUploadHeap,
-                       std::vector<UINT8 *> &texture,
+                       const std::vector<UINT8 *> &texture,
+                       ComPtr<ID3D12Resource> &m_texture,
+                       ComPtr<ID3D12Resource> &textureUploadHeap,
                        int TextureWidth,
                        int TextureHeight,
                        int TexturePixelSize,

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
@@ -135,7 +135,7 @@ void FishModelD3D12::init()
                                contextD3D12->staticSamplers.data(),
                                D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    contextD3D12->createRootSignature(&rootSignatureDesc, m_rootSignature);
+    contextD3D12->createRootSignature(rootSignatureDesc, m_rootSignature);
 
     contextD3D12->createGraphicsPipelineState(inputElementDescs, m_rootSignature,
                                               programD3D12->getVSModule(),
@@ -177,7 +177,7 @@ void FishModelD3D12::draw()
     }
 }
 
-void FishModelD3D12::updatePerInstanceUniforms(WorldUniforms *worldUniforms) {}
+void FishModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms) {}
 
 void FishModelD3D12::updateFishPerUniforms(float x,
                                            float y,

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.h
@@ -32,7 +32,7 @@ class FishModelD3D12 : public FishModel
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void updateFishPerUniforms(float x,
                                float y,
                                float z,

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -144,7 +144,7 @@ void FishModelInstancedDrawD3D12::init()
                                contextD3D12->staticSamplers.data(),
                                D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    contextD3D12->createRootSignature(&rootSignatureDesc, m_rootSignature);
+    contextD3D12->createRootSignature(rootSignatureDesc, m_rootSignature);
 
     contextD3D12->createGraphicsPipelineState(inputElementDescs, m_rootSignature,
                                               programD3D12->getVSModule(),
@@ -182,7 +182,7 @@ void FishModelInstancedDrawD3D12::draw()
     commandList->DrawIndexedInstanced(indicesBuffer->getTotalComponents(), instance, 0, 0, 0);
 }
 
-void FishModelInstancedDrawD3D12::updatePerInstanceUniforms(WorldUniforms *worldUniforms) {}
+void FishModelInstancedDrawD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms) {}
 
 void FishModelInstancedDrawD3D12::updateFishPerUniforms(float x,
                                                         float y,

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
@@ -32,7 +32,7 @@ class FishModelInstancedDrawD3D12 : public FishModel
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void updateFishPerUniforms(float x,
                                float y,
                                float z,

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
@@ -132,7 +132,7 @@ void GenericModelD3D12::init()
                                contextD3D12->staticSamplers.data(),
                                D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    contextD3D12->createRootSignature(&rootSignatureDesc, m_rootSignature);
+    contextD3D12->createRootSignature(rootSignatureDesc, m_rootSignature);
 
     contextD3D12->createGraphicsPipelineState(inputElementDescs, m_rootSignature,
                                               programD3D12->getVSModule(),
@@ -179,9 +179,9 @@ void GenericModelD3D12::draw()
     instance = 0;
 }
 
-void GenericModelD3D12::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void GenericModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
-    worldUniformPer.WorldUniforms[instance] = *worldUniforms;
+    worldUniformPer.WorldUniforms[instance] = worldUniforms;
 
     instance++;
 }

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.h
@@ -32,7 +32,7 @@ class GenericModelD3D12 : public Model
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
     TextureD3D12 *diffuseTexture;
     TextureD3D12 *normalTexture;

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
@@ -94,7 +94,7 @@ void InnerModelD3D12::init()
                                contextD3D12->staticSamplers.data(),
                                D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    contextD3D12->createRootSignature(&rootSignatureDesc, m_rootSignature);
+    contextD3D12->createRootSignature(rootSignatureDesc, m_rootSignature);
 
     contextD3D12->createGraphicsPipelineState(inputElementDescs, m_rootSignature,
                                               programD3D12->getVSModule(),
@@ -125,9 +125,9 @@ void InnerModelD3D12::draw()
     commandList->DrawIndexedInstanced(indicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void InnerModelD3D12::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void InnerModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
-    memcpy(&worldUniformPer, worldUniforms, sizeof(WorldUniforms));
+    memcpy(&worldUniformPer, &worldUniforms, sizeof(WorldUniforms));
 
     CD3DX12_RANGE readRange(0, 0);
     UINT8 *m_pCbvDataBegin;

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.h
@@ -28,7 +28,7 @@ class InnerModelD3D12 : public Model
     void init() override;
     void prepareForDraw() const override;
     void draw() override;
-    void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &WorldUniforms) override;
 
     struct InnerUniforms
     {

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
@@ -85,7 +85,7 @@ void OutsideModelD3D12::init()
                                contextD3D12->staticSamplers.data(),
                                D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    contextD3D12->createRootSignature(&rootSignatureDesc, m_rootSignature);
+    contextD3D12->createRootSignature(rootSignatureDesc, m_rootSignature);
 
     contextD3D12->createGraphicsPipelineState(inputElementDescs, m_rootSignature,
                                               programD3D12->getVSModule(),
@@ -116,9 +116,9 @@ void OutsideModelD3D12::draw()
     commandList->DrawIndexedInstanced(indicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void OutsideModelD3D12::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void OutsideModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
-    memcpy(&worldUniformPer, worldUniforms, sizeof(WorldUniforms));
+    memcpy(&worldUniformPer, &worldUniforms, sizeof(WorldUniforms));
 
     CD3DX12_RANGE readRange(0, 0);
     UINT8 *m_pCbvDataBegin;

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
@@ -31,7 +31,7 @@ class OutsideModelD3D12 : public Model
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
     TextureD3D12 *diffuseTexture;
     TextureD3D12 *normalTexture;

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
@@ -4,7 +4,7 @@
 #include "ContextD3D12.h"
 #include "ProgramD3D12.h"
 
-ProgramD3D12::ProgramD3D12(ContextD3D12 *context, std::string vId, std::string fId)
+ProgramD3D12::ProgramD3D12(ContextD3D12 *context, const std::string &vId, const std::string &fId)
     : Program(vId, fId), vertexShader(nullptr), pixelShader(nullptr), context(context)
 {
 }

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.h
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.h
@@ -30,7 +30,7 @@ class ProgramD3D12 : public Program
 {
   public:
     ProgramD3D12() {}
-    ProgramD3D12(ContextD3D12 *context, std::string vId, std::string fId);
+    ProgramD3D12(ContextD3D12 *context, const std::string &vId, const std::string &fId);
     ~ProgramD3D12() override;
 
     void loadProgram();

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
@@ -93,7 +93,7 @@ void SeaweedModelD3D12::init()
                                contextD3D12->staticSamplers.data(),
                                D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    contextD3D12->createRootSignature(&rootSignatureDesc, m_rootSignature);
+    contextD3D12->createRootSignature(rootSignatureDesc, m_rootSignature);
 
     contextD3D12->createGraphicsPipelineState(inputElementDescs, m_rootSignature,
                                               programD3D12->getVSModule(),
@@ -138,9 +138,9 @@ void SeaweedModelD3D12::draw()
     instance = 0;
 }
 
-void SeaweedModelD3D12::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void SeaweedModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
-    worldUniformPer.worldUniforms[instance] = *worldUniforms;
+    worldUniformPer.worldUniforms[instance] = worldUniforms;
     seaweedPer.seaweed[instance].time       = mAquarium->g.mclock + instance;
 
     instance++;

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
@@ -29,7 +29,7 @@ class SeaweedModelD3D12 : public SeaweedModel
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
     TextureD3D12 *diffuseTexture;
     TextureD3D12 *normalTexture;

--- a/src/aquarium-optimized/d3d12/TextureD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/TextureD3D12.cpp
@@ -6,7 +6,7 @@
 
 TextureD3D12::~TextureD3D12() {}
 
-TextureD3D12::TextureD3D12(ContextD3D12 *context, std::string name, std::string url)
+TextureD3D12::TextureD3D12(ContextD3D12 *context, const std::string &name, const std::string &url)
     : Texture(name, url, true),
       mTextureDimension(D3D12_RESOURCE_DIMENSION_TEXTURE2D),
       mTextureViewDimension(D3D12_SRV_DIMENSION_TEXTURE2D),
@@ -17,7 +17,7 @@ TextureD3D12::TextureD3D12(ContextD3D12 *context, std::string name, std::string 
 }
 
 TextureD3D12::TextureD3D12(ContextD3D12 *context,
-                           std::string name,
+                           const std::string &name,
                            const std::vector<std::string> &urls)
     : Texture(name, urls, false),
       mTextureDimension(D3D12_RESOURCE_DIMENSION_TEXTURE2D),
@@ -45,7 +45,7 @@ void TextureD3D12::loadTexture()
         textureDesc.SampleDesc.Quality  = 0;
         textureDesc.Dimension           = mTextureDimension;
 
-        context->createTexture(textureDesc, mTexture, mTextureUploadHeap, mPixelVec, mWidth,
+        context->createTexture(textureDesc, mPixelVec, mTexture, mTextureUploadHeap, mWidth,
                                mHeight, 4u, textureDesc.MipLevels, textureDesc.DepthOrArraySize);
     }
     else
@@ -64,7 +64,7 @@ void TextureD3D12::loadTexture()
         textureDesc.SampleDesc.Quality = 0;
         textureDesc.Dimension          = mTextureDimension;
 
-        context->createTexture(textureDesc, mTexture, mTextureUploadHeap, mResizedVec, mWidth,
+        context->createTexture(textureDesc, mResizedVec, mTexture, mTextureUploadHeap, mWidth,
                                mHeight, 4u, textureDesc.MipLevels, textureDesc.DepthOrArraySize);
     }
 }

--- a/src/aquarium-optimized/d3d12/TextureD3D12.h
+++ b/src/aquarium-optimized/d3d12/TextureD3D12.h
@@ -23,8 +23,10 @@ class TextureD3D12 : public Texture
 {
   public:
     ~TextureD3D12() override;
-    TextureD3D12(ContextD3D12 *context, std::string name, std::string url);
-    TextureD3D12(ContextD3D12 *context, std::string name, const std::vector<std::string> &urls);
+    TextureD3D12(ContextD3D12 *context, const std::string &name, const std::string &url);
+    TextureD3D12(ContextD3D12 *context,
+                 const std::string &name,
+                 const std::vector<std::string> &urls);
 
     D3D12_RESOURCE_DIMENSION getTextureDimension() { return mTextureDimension; }
     D3D12_SRV_DIMENSION getTextureViewDimension() { return mTextureViewDimension; }

--- a/src/aquarium-optimized/dawn/BufferDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferDawn.cpp
@@ -12,7 +12,7 @@
 BufferDawn::BufferDawn(ContextDawn *context,
                        int totalCmoponents,
                        int numComponents,
-                       std::vector<float> &buffer,
+                       std::vector<float> *buffer,
                        bool isIndex)
     : mUsageBit(isIndex ? dawn::BufferUsageBit::Index : dawn::BufferUsageBit::Vertex),
       mTotoalComponents(totalCmoponents),
@@ -25,16 +25,16 @@ BufferDawn::BufferDawn(ContextDawn *context,
         int dummyCount = 4 - mTotoalComponents % 4;
         for (int i = 0; i < dummyCount; i++)
         {
-            buffer.push_back(0.0f);
+            buffer->push_back(0.0f);
         }
     }
-    mBuf = context->createBufferFromData(buffer.data(), sizeof(float) * static_cast<int>(buffer.size()), mUsageBit);
+    mBuf = context->createBufferFromData(buffer->data(), sizeof(float) * static_cast<int>(buffer->size()), mUsageBit);
 }
 
 BufferDawn::BufferDawn(ContextDawn *context,
                        int totalCmoponents,
                        int numComponents,
-                       std::vector<unsigned short> &buffer,
+                       std::vector<unsigned short> *buffer,
                        bool isIndex)
     : mUsageBit(isIndex ? dawn::BufferUsageBit::Index : dawn::BufferUsageBit::Vertex),
       mTotoalComponents(totalCmoponents),
@@ -47,10 +47,11 @@ BufferDawn::BufferDawn(ContextDawn *context,
         int dummyCount = 4 - mTotoalComponents % 4;
         for (int i = 0; i < dummyCount; i++)
         {
-            buffer.push_back(0.0f);
+            buffer->push_back(0.0f);
         }
     }
-    mBuf = context->createBufferFromData(buffer.data(), sizeof(unsigned short) * static_cast<int>(buffer.size()), mUsageBit);
+    mBuf = context->createBufferFromData(
+        buffer->data(), sizeof(unsigned short) * static_cast<int>(buffer->size()), mUsageBit);
 }
 
 BufferDawn::~BufferDawn()

--- a/src/aquarium-optimized/dawn/BufferDawn.h
+++ b/src/aquarium-optimized/dawn/BufferDawn.h
@@ -22,12 +22,12 @@ class BufferDawn : public Buffer
     BufferDawn(ContextDawn *context,
                int totalCmoponents,
                int numComponents,
-               std::vector<float> &buffer,
+               std::vector<float> *buffer,
                bool isIndex);
     BufferDawn(ContextDawn *context,
                int totalCmoponents,
                int numComponents,
-               std::vector<unsigned short> &buffer,
+               std::vector<unsigned short> *buffer,
                bool isIndex);
     ~BufferDawn() override;
 

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -286,36 +286,36 @@ void ContextDawn::initAvailableToggleBitset(BACKENDTYPE backendType)
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
 }
 
-Texture *ContextDawn::createTexture(std::string name, std::string url)
+Texture *ContextDawn::createTexture(const std::string &name, const std::string &url)
 {
     Texture *texture = new TextureDawn(this, name, url);
     texture->loadTexture();
     return texture;
 }
 
-Texture *ContextDawn::createTexture(std::string name, const std::vector<std::string> &urls)
+Texture *ContextDawn::createTexture(const std::string &name, const std::vector<std::string> &urls)
 {
     Texture *texture = new TextureDawn(this, name, urls);
     texture->loadTexture();
     return texture;
 }
 
-dawn::Texture ContextDawn::createTexture(const dawn::TextureDescriptor & descriptor) const
+dawn::Texture ContextDawn::createTexture(const dawn::TextureDescriptor &descriptor) const
 {
     return device.CreateTexture(&descriptor);
 }
 
-dawn::Sampler ContextDawn::createSampler(const dawn::SamplerDescriptor & descriptor) const
+dawn::Sampler ContextDawn::createSampler(const dawn::SamplerDescriptor &descriptor) const
 {
     return device.CreateSampler(&descriptor);
 }
 
-dawn::Buffer ContextDawn::createBufferFromData(const void * pixels, int size, dawn::BufferUsageBit usage) const
+dawn::Buffer ContextDawn::createBufferFromData(const void *pixels, int size, dawn::BufferUsageBit usage) const
 {
     return utils::CreateBufferFromData(device, pixels, size, usage);
 }
 
-dawn::BufferCopyView ContextDawn::createBufferCopyView(const dawn::Buffer& buffer,
+dawn::BufferCopyView ContextDawn::createBufferCopyView(const dawn::Buffer &buffer,
     uint32_t offset,
     uint32_t rowPitch,
     uint32_t imageHeight) const {
@@ -365,7 +365,7 @@ dawn::PipelineLayout ContextDawn::MakeBasicPipelineLayout(
 dawn::RenderPipeline ContextDawn::createRenderPipeline(
     dawn::PipelineLayout pipelineLayout,
     ProgramDawn *programDawn,
-    dawn::VertexInputDescriptor &vertexInputDescriptor,
+    const dawn::VertexInputDescriptor &vertexInputDescriptor,
     bool enableBlend) const
 {
     const dawn::ShaderModule &vsModule = programDawn->getVSModule();
@@ -502,19 +502,20 @@ void ContextDawn::updateWorldlUniforms(Aquarium* aquarium)
     setBufferData(lightWorldPositionBuffer, 0, sizeof(LightWorldPositionUniform), &aquarium->lightWorldPositionUniform);
 }
 
-Buffer *ContextDawn::createBuffer(int numComponents, std::vector<float> &buf, bool isIndex)
+Buffer *ContextDawn::createBuffer(int numComponents, std::vector<float> *buf, bool isIndex)
 {
-    Buffer *buffer = new BufferDawn(this, static_cast<int>(buf.size()), numComponents, buf, isIndex);
+    Buffer *buffer = new BufferDawn(this, static_cast<int>(buf->size()), numComponents, buf, isIndex);
     return buffer;
 }
 
-Buffer *ContextDawn::createBuffer(int numComponents, std::vector<unsigned short> &buf, bool isIndex)
+Buffer *ContextDawn::createBuffer(int numComponents, std::vector<unsigned short> *buf, bool isIndex)
 {
-    Buffer *buffer = new BufferDawn(this, static_cast<int>(buf.size()), numComponents, buf, isIndex);
+    Buffer *buffer =
+        new BufferDawn(this, static_cast<int>(buf->size()), numComponents, buf, isIndex);
     return buffer;
 }
 
-Program *ContextDawn::createProgram(std::string vId, std::string fId)
+Program *ContextDawn::createProgram(const std::string &vId, const std::string &fId)
 {
     ProgramDawn* program = new ProgramDawn(this, vId, fId);
     program->loadProgram();

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -43,15 +43,15 @@ class ContextDawn : public Context
     void preFrame() override;
 
     Model *createModel(Aquarium* aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
-    Buffer *createBuffer(int numComponents, std::vector<float> &buffer, bool isIndex) override;
+    Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) override;
     Buffer *createBuffer(int numComponents,
-                         std::vector<unsigned short> &buffer,
+                         std::vector<unsigned short> *buffer,
                          bool isIndex) override;
 
-    Program *createProgram(std::string vId, std::string fId) override;
+    Program *createProgram(const std::string &vId, const std::string &fId) override;
 
-    Texture *createTexture(std::string name, std::string url) override;
-    Texture *createTexture(std::string name, const std::vector<std::string> &urls) override;
+    Texture *createTexture(const std::string &name, const std::string &url) override;
+    Texture *createTexture(const std::string &name, const std::vector<std::string> &urls) override;
     dawn::Texture createTexture(const dawn::TextureDescriptor &descriptor) const;
     dawn::Sampler createSampler(const dawn::SamplerDescriptor &descriptor) const;
     dawn::Buffer createBufferFromData(const void* pixels, int size, dawn::BufferUsageBit usage) const;
@@ -74,11 +74,11 @@ class ContextDawn : public Context
         std::vector<dawn::BindGroupLayout> bindingsInitializer) const;
     dawn::RenderPipeline createRenderPipeline(dawn::PipelineLayout pipelineLayout,
                                               ProgramDawn *programDawn,
-                                              dawn::VertexInputDescriptor &vertexInputDescriptor,
+                                              const dawn::VertexInputDescriptor &vertexInputDescriptor,
                                               bool enableBlend) const;
     dawn::TextureView createDepthStencilView() const;
     dawn::Buffer createBuffer(uint32_t size, dawn::BufferUsageBit bit) const;
-    void setBufferData(const dawn::Buffer& buffer, uint32_t start, uint32_t size, const void* pixels) const;
+    void setBufferData(const dawn::Buffer &buffer, uint32_t start, uint32_t size, const void* pixels) const;
     dawn::BindGroup makeBindGroup(
         const dawn::BindGroupLayout &layout,
         std::initializer_list<utils::BindingInitializationHelper> bindingsInitializer) const;
@@ -87,6 +87,7 @@ class ContextDawn : public Context
     void updateWorldlUniforms(Aquarium* aquarium) override;
     const dawn::Device &getDevice() const { return device; }
     const dawn::RenderPassEncoder &getRenderPass() const { return mRenderPass; }
+
     std::vector<dawn::CommandBuffer> mCommandBuffers;
     dawn::Queue queue;
 

--- a/src/aquarium-optimized/dawn/FishModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelDawn.cpp
@@ -235,7 +235,7 @@ void FishModelDawn::draw()
     }
 }
 
-void FishModelDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms) {}
+void FishModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms) {}
 
 void FishModelDawn::updateFishPerUniforms(float x,
                                           float y,

--- a/src/aquarium-optimized/dawn/FishModelDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelDawn.h
@@ -30,7 +30,7 @@ class FishModelDawn : public FishModel
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void updateFishPerUniforms(float x,
                                float y,
                                float z,

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -202,7 +202,7 @@ void FishModelInstancedDrawDawn::draw()
     pass.DrawIndexed(indicesBuffer->getTotalComponents(), instance, 0, 0, 0);
 }
 
-void FishModelInstancedDrawDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms) {}
+void FishModelInstancedDrawDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms) {}
 
 void FishModelInstancedDrawDawn::updateFishPerUniforms(float x,
                                                        float y,

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
@@ -30,7 +30,7 @@ class FishModelInstancedDrawDawn : public FishModel
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &WorldUniforms) override;
     void updateFishPerUniforms(float x,
                                float y,
                                float z,

--- a/src/aquarium-optimized/dawn/GenericModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.cpp
@@ -234,9 +234,9 @@ void GenericModelDawn::draw()
     instance = 0;
 }
 
-void GenericModelDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void GenericModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
-    worldUniformPer.WorldUniforms[instance] = *worldUniforms;
+    worldUniformPer.WorldUniforms[instance] = worldUniforms;
 
     instance++;
 }

--- a/src/aquarium-optimized/dawn/GenericModelDawn.h
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.h
@@ -30,7 +30,7 @@ class GenericModelDawn : public Model
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
     TextureDawn *diffuseTexture;
     TextureDawn *normalTexture;

--- a/src/aquarium-optimized/dawn/InnerModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.cpp
@@ -151,9 +151,9 @@ void InnerModelDawn::draw()
     pass.DrawIndexed(indicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void InnerModelDawn::updatePerInstanceUniforms(WorldUniforms* worldUniforms)
+void InnerModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
-    std::memcpy(&worldUniformPer, worldUniforms, sizeof(WorldUniforms));
+    std::memcpy(&worldUniformPer, &worldUniforms, sizeof(WorldUniforms));
 
     contextDawn->setBufferData(viewBuffer, 0, sizeof(WorldUniforms), &worldUniformPer);
 }

--- a/src/aquarium-optimized/dawn/InnerModelDawn.h
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.h
@@ -19,13 +19,13 @@
 class InnerModelDawn : public Model
 {
   public:
-    InnerModelDawn(const Context* context, Aquarium* aquarium, MODELGROUP type, MODELNAME name, bool blend);
+    InnerModelDawn(const Context *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
     ~InnerModelDawn();
 
     void init() override;
     void prepareForDraw() const override;
     void draw() override;
-    void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &WorldUniforms) override;
 
     struct InnerUniforms
     {

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
@@ -145,8 +145,9 @@ void OutsideModelDawn::draw()
     pass.DrawIndexed(indicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void OutsideModelDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms) {
-    memcpy(&worldUniformPer, worldUniforms, sizeof(WorldUniforms));
+void OutsideModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+{
+    memcpy(&worldUniformPer, &worldUniforms, sizeof(WorldUniforms));
 
     contextDawn->setBufferData(viewBuffer, 0, sizeof(WorldUniforms), &worldUniformPer);
 }

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.h
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.h
@@ -19,14 +19,14 @@
 class OutsideModelDawn : public Model
 {
 public:
-    OutsideModelDawn(const Context* context, Aquarium* aquarium, MODELGROUP type, MODELNAME name, bool blend);
+    OutsideModelDawn(const Context *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
     ~OutsideModelDawn();
 
     void init() override;
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
     TextureDawn *diffuseTexture;
     TextureDawn *normalTexture;

--- a/src/aquarium-optimized/dawn/ProgramDawn.cpp
+++ b/src/aquarium-optimized/dawn/ProgramDawn.cpp
@@ -12,7 +12,7 @@
 #include "ProgramDawn.h"
 #include "common/AQUARIUM_ASSERT.h"
 
-ProgramDawn::ProgramDawn(ContextDawn *context, std::string vId, std::string fId)
+ProgramDawn::ProgramDawn(ContextDawn *context, const std::string &vId, const std::string &fId)
     : Program(vId, fId), vsModule(nullptr), fsModule(nullptr), context(context)
 {
 }

--- a/src/aquarium-optimized/dawn/ProgramDawn.h
+++ b/src/aquarium-optimized/dawn/ProgramDawn.h
@@ -29,7 +29,7 @@ class ProgramDawn : public Program
 {
 public:
     ProgramDawn() {}
-    ProgramDawn(ContextDawn *context, std::string vId, std::string fId);
+    ProgramDawn(ContextDawn *context, const std::string &vId, const std::string &fId);
     ~ProgramDawn() override;
 
     void loadProgram();

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
@@ -131,9 +131,9 @@ void SeaweedModelDawn::draw()
     instance = 0;
 }
 
-void SeaweedModelDawn::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void SeaweedModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
-    worldUniformPer.worldUniforms[instance] = *worldUniforms;
+    worldUniformPer.worldUniforms[instance] = worldUniforms;
     seaweedPer.time[instance]             = mAquarium->g.mclock + instance;
 
     instance++;

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.h
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.h
@@ -19,14 +19,14 @@
 class SeaweedModelDawn : public SeaweedModel
 {
   public:
-    SeaweedModelDawn(const Context* context, Aquarium* aquarium, MODELGROUP type, MODELNAME name, bool blend);
+    SeaweedModelDawn(const Context *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
     ~SeaweedModelDawn();
 
     void init() override;
     void prepareForDraw() const override;
     void draw() override;
 
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
 
     TextureDawn *diffuseTexture;

--- a/src/aquarium-optimized/dawn/TextureDawn.cpp
+++ b/src/aquarium-optimized/dawn/TextureDawn.cpp
@@ -22,7 +22,7 @@ TextureDawn::~TextureDawn() {
     mSampler     = nullptr;
 }
 
-TextureDawn::TextureDawn(ContextDawn *context, std::string name, std::string url)
+TextureDawn::TextureDawn(ContextDawn *context, const std::string &name, const std::string &url)
     : Texture(name, url, true),
       mTextureDimension(dawn::TextureDimension::e2D),
       mTextureViewDimension(dawn::TextureViewDimension::e2D),
@@ -35,7 +35,7 @@ TextureDawn::TextureDawn(ContextDawn *context, std::string name, std::string url
 }
 
 TextureDawn::TextureDawn(ContextDawn *context,
-                         std::string name,
+                         const std::string &name,
                          const std::vector<std::string> &urls)
     : Texture(name, urls, false),
       mTextureDimension(dawn::TextureDimension::e2D),

--- a/src/aquarium-optimized/dawn/TextureDawn.h
+++ b/src/aquarium-optimized/dawn/TextureDawn.h
@@ -19,8 +19,10 @@ class TextureDawn : public Texture
 {
   public:
     ~TextureDawn() override;
-    TextureDawn(ContextDawn* context, std::string name, std::string url);
-    TextureDawn(ContextDawn *context, std::string name, const std::vector<std::string> &urls);
+    TextureDawn(ContextDawn *context, const std::string &name, const std::string &url);
+    TextureDawn(ContextDawn *context,
+                const std::string &name,
+                const std::vector<std::string> &urls);
 
     const dawn::Texture &getTextureId() const { return mTexture; }
     const dawn::Sampler &getSampler() const { return mSampler; }

--- a/src/aquarium-optimized/opengl/BufferGL.cpp
+++ b/src/aquarium-optimized/opengl/BufferGL.cpp
@@ -25,7 +25,7 @@ BufferGL::BufferGL(ContextGL *context,
       mStride(0),
       mOffset(nullptr)
 {
-    context->generateBuffer(&mBuf);
+    mBuf = context->generateBuffer();
 }
 
 void BufferGL::loadBuffer(const std::vector<float> &buf)
@@ -42,5 +42,5 @@ void BufferGL::loadBuffer(const std::vector<unsigned short> &buf)
 
 BufferGL::~BufferGL()
 {
-    context->deleteBuffer(&mBuf);
+    context->deleteBuffer(mBuf);
 }

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -321,23 +321,25 @@ EGLBoolean ContextGL::FindEGLConfig(EGLDisplay dpy, const EGLint *attrib_list, E
 }
 #endif
 
-Texture *ContextGL::createTexture(std::string name, std::string url)
+Texture *ContextGL::createTexture(const std::string &name, const std::string &url)
 {
     TextureGL *texture = new TextureGL(this, name, url);
     texture->loadTexture();
     return texture;
 }
 
-Texture *ContextGL::createTexture(std::string name, const std::vector<std::string> &urls)
+Texture *ContextGL::createTexture(const std::string &name, const std::vector<std::string> &urls)
 {
     TextureGL *texture = new TextureGL(this, name, urls);
     texture->loadTexture();
     return texture;
 }
 
-void ContextGL::generateTexture(unsigned int *texture)
+unsigned int ContextGL::generateTexture()
 {
-    glGenTextures(1, texture);
+    unsigned int texture;
+    glGenTextures(1, &texture);
+    return texture;
 }
 
 void ContextGL::bindTexture(unsigned int target, unsigned int textureId)
@@ -345,9 +347,9 @@ void ContextGL::bindTexture(unsigned int target, unsigned int textureId)
     glBindTexture(target, textureId);
 }
 
-void ContextGL::deleteTexture(unsigned int *texture)
+void ContextGL::deleteTexture(unsigned int texture)
 {
-    glDeleteTextures(1, texture);
+    glDeleteTextures(1, &texture);
 }
 
 void ContextGL::uploadTexture(unsigned int target,
@@ -388,24 +390,24 @@ void ContextGL::initAvailableToggleBitset(BACKENDTYPE backendType)
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
 }
 
-Buffer *ContextGL::createBuffer(int numComponents, std::vector<float> &buf, bool isIndex)
+Buffer *ContextGL::createBuffer(int numComponents, std::vector<float> *buf, bool isIndex)
 {
-    BufferGL *buffer = new BufferGL(this, static_cast<int>(buf.size()), numComponents, isIndex, GL_FLOAT, false);
-    buffer->loadBuffer(buf);
+    BufferGL *buffer = new BufferGL(this, static_cast<int>(buf->size()), numComponents, isIndex, GL_FLOAT, false);
+    buffer->loadBuffer(*buf);
 
     return buffer;
 }
 
-Buffer *ContextGL::createBuffer(int numComponents, std::vector<unsigned short> &buf, bool isIndex)
+Buffer *ContextGL::createBuffer(int numComponents, std::vector<unsigned short> *buf, bool isIndex)
 {
-    BufferGL *buffer =
-        new BufferGL(this, static_cast<int>(buf.size()), numComponents, isIndex, GL_UNSIGNED_SHORT, true);
-    buffer->loadBuffer(buf);
+    BufferGL *buffer = new BufferGL(this, static_cast<int>(buf->size()), numComponents, isIndex,
+                                    GL_UNSIGNED_SHORT, true);
+    buffer->loadBuffer(*buf);
 
     return buffer;
 }
 
-Program *ContextGL::createProgram(std::string vId, std::string fId)
+Program *ContextGL::createProgram(const std::string &vId, const std::string &fId)
 {
     ProgramGL *program = new ProgramGL(this, vId, fId);
     program->loadProgram();
@@ -494,14 +496,14 @@ void ContextGL::destoryImgUI()
     ImGui::DestroyContext();
 }
 
-int ContextGL::getUniformLocation(unsigned int programId, std::string name) const
+int ContextGL::getUniformLocation(unsigned int programId, const std::string &name) const
 {
     GLint index = glGetUniformLocation(programId, name.c_str());
     ASSERT(glGetError() == GL_NO_ERROR);
     return index;
 }
 
-int ContextGL::getAttribLocation(unsigned int programId, std::string name) const
+int ContextGL::getAttribLocation(unsigned int programId, const std::string &name) const
 {
     GLint index = glGetAttribLocation(programId, name.c_str());
     ASSERT(glGetError() == GL_NO_ERROR);
@@ -520,10 +522,10 @@ void ContextGL::enableBlend(bool flag) const
     }
 }
 
-void ContextGL::drawElements(BufferGL *buffer) const
+void ContextGL::drawElements(const BufferGL &buffer) const
 {
-    GLint totalComponents = buffer->getTotalComponents();
-    GLenum type           = buffer->getType();
+    GLint totalComponents = buffer.getTotalComponents();
+    GLenum type           = buffer.getType();
     glDrawElements(GL_TRIANGLES, totalComponents, type, 0);
 
     ASSERT(glGetError() == GL_NO_ERROR);
@@ -605,36 +607,38 @@ void ContextGL::setUniform(int index, const float *v, int type) const
     ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-void ContextGL::setTexture(const TextureGL *texture, int index, int unit) const
+void ContextGL::setTexture(const TextureGL &texture, int index, int unit) const
 {
     ASSERT(index != -1);
     glUniform1i(index, unit);
     glActiveTexture(GL_TEXTURE0 + unit);
-    glBindTexture(texture->getTarget(), texture->getTextureId());
+    glBindTexture(texture.getTarget(), texture.getTextureId());
 
     ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-void ContextGL::setAttribs(BufferGL *bufferGL, int index) const
+void ContextGL::setAttribs(const BufferGL &bufferGL, int index) const
 {
     ASSERT(index != -1);
-    glBindBuffer(bufferGL->getTarget(), bufferGL->getBuffer());
+    glBindBuffer(bufferGL.getTarget(), bufferGL.getBuffer());
 
     glEnableVertexAttribArray(index);
-    glVertexAttribPointer(index, bufferGL->getNumComponents(), bufferGL->getType(),
-                          bufferGL->getNormalize(), bufferGL->getStride(), bufferGL->getOffset());
+    glVertexAttribPointer(index, bufferGL.getNumComponents(), bufferGL.getType(),
+                          bufferGL.getNormalize(), bufferGL.getStride(), bufferGL.getOffset());
 
     ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-void ContextGL::setIndices(BufferGL *bufferGL) const
+void ContextGL::setIndices(const BufferGL &bufferGL) const
 {
-    glBindBuffer(bufferGL->getTarget(), bufferGL->getBuffer());
+    glBindBuffer(bufferGL.getTarget(), bufferGL.getBuffer());
 }
 
-void ContextGL::generateVAO(unsigned int *mVAO)
+unsigned int ContextGL::generateVAO()
 {
-    glGenVertexArrays(1, mVAO);
+    unsigned int vao;
+    glGenVertexArrays(1, &vao);
+    return vao;
 }
 
 void ContextGL::bindVAO(unsigned int vao) const
@@ -642,19 +646,21 @@ void ContextGL::bindVAO(unsigned int vao) const
     glBindVertexArray(vao);
 }
 
-void ContextGL::deleteVAO(unsigned int *mVAO)
+void ContextGL::deleteVAO(unsigned int mVAO)
 {
-    glDeleteVertexArrays(1, mVAO);
+    glDeleteVertexArrays(1, &mVAO);
 }
 
-void ContextGL::generateBuffer(unsigned int *buf)
+unsigned int ContextGL::generateBuffer()
 {
-    glGenBuffers(1, buf);
+    unsigned int buf;
+    glGenBuffers(1, &buf);
+    return buf;
 }
 
-void ContextGL::deleteBuffer(unsigned int *buf)
+void ContextGL::deleteBuffer(unsigned int buf)
 {
-    glDeleteBuffers(1, buf);
+    glDeleteBuffers(1, &buf);
 }
 
 void ContextGL::bindBuffer(unsigned int target, unsigned int buf)
@@ -676,9 +682,9 @@ void ContextGL::uploadBuffer(unsigned int target, const std::vector<unsigned sho
     ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-void ContextGL::generateProgram(unsigned int *program)
+unsigned int ContextGL::generateProgram()
 {
-    *program = glCreateProgram();
+    return glCreateProgram();
 }
 
 void ContextGL::setProgram(unsigned int program)
@@ -686,9 +692,9 @@ void ContextGL::setProgram(unsigned int program)
     glUseProgram(program);
 }
 
-void ContextGL::deleteProgram(unsigned int *program)
+void ContextGL::deleteProgram(unsigned int program)
 {
-    glDeleteProgram(*program);
+    glDeleteProgram(program);
 }
 
 bool ContextGL::compileProgram(unsigned int programId,

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -51,40 +51,40 @@ class ContextGL : public Context
     void enableBlend(bool flag) const;
 
     Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
-    int getUniformLocation(unsigned int programId, std::string name) const;
-    int getAttribLocation(unsigned int programId, std::string name) const;
+    int getUniformLocation(unsigned int programId, const std::string &name) const;
+    int getAttribLocation(unsigned int programId, const std::string & name) const;
     void setUniform(int index, const float *v, int type) const;
-    void setTexture(const TextureGL *texture, int index, int unit) const;
-    void setAttribs(BufferGL *bufferGL, int index) const;
-    void setIndices(BufferGL *bufferGL) const;
-    void drawElements(BufferGL *buffer) const;
+    void setTexture(const TextureGL &texture, int index, int unit) const;
+    void setAttribs(const BufferGL &bufferGL, int index) const;
+    void setIndices(const BufferGL &bufferGL) const;
+    void drawElements(const BufferGL &buffer) const;
 
-    Buffer *createBuffer(int numComponents, std::vector<float> &buffer, bool isIndex) override;
+    Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) override;
     Buffer *createBuffer(int numComponents,
-                         std::vector<unsigned short> &buffer,
+                         std::vector<unsigned short> *buffer,
                          bool isIndex) override;
-    void generateBuffer(unsigned int *buf);
-    void deleteBuffer(unsigned int *buf);
+    unsigned int generateBuffer();
+    void deleteBuffer(unsigned int buf);
     void bindBuffer(unsigned int target, unsigned int buf);
     void uploadBuffer(unsigned int target, const std::vector<float> &buf);
     void uploadBuffer(unsigned int target, const std::vector<unsigned short> &buf);
 
-    Program *createProgram(std::string vId, std::string fId) override;
-    void generateProgram(unsigned int *program);
+    Program *createProgram(const std::string &vId, const std::string &fId) override;
+    unsigned int generateProgram();
     void setProgram(unsigned int program);
-    void deleteProgram(unsigned int *program);
+    void deleteProgram(unsigned int program);
     bool compileProgram(unsigned int programId,
                         const std::string &VertexShaderCode,
                         const std::string &FragmentShaderCode);
     void bindVAO(unsigned int vao) const;
-    void generateVAO(unsigned int *mVAO);
-    void deleteVAO(unsigned int *mVAO);
+    unsigned int generateVAO();
+    void deleteVAO(unsigned int vao);
 
-    Texture *createTexture(std::string name, std::string url) override;
-    Texture *createTexture(std::string name, const std::vector<std::string> &urls) override;
-    void generateTexture(unsigned int *texture);
+    Texture *createTexture(const std::string &name, const std::string &url) override;
+    Texture *createTexture(const std::string &name, const std::vector<std::string> &urls) override;
+    unsigned int generateTexture();
     void bindTexture(unsigned int target, unsigned int texture);
-    void deleteTexture(unsigned int *texture);
+    void deleteTexture(unsigned int texture);
     void uploadTexture(unsigned int target,
                        unsigned int format,
                        int width,

--- a/src/aquarium-optimized/opengl/FishModelGL.cpp
+++ b/src/aquarium-optimized/opengl/FishModelGL.cpp
@@ -99,7 +99,7 @@ void FishModelGL::init()
 
 void FishModelGL::draw()
 {
-    contextGL->drawElements(indicesBuffer);
+    contextGL->drawElements(*indicesBuffer);
 }
 
 void FishModelGL::prepareForDraw() const
@@ -110,14 +110,14 @@ void FishModelGL::prepareForDraw() const
     ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
     contextGL->bindVAO(programGL->getVAOId());
 
-    contextGL->setAttribs(positionBuffer.first, positionBuffer.second);
-    contextGL->setAttribs(normalBuffer.first, normalBuffer.second);
-    contextGL->setAttribs(texCoordBuffer.first, texCoordBuffer.second);
+    contextGL->setAttribs(*positionBuffer.first, positionBuffer.second);
+    contextGL->setAttribs(*normalBuffer.first, normalBuffer.second);
+    contextGL->setAttribs(*texCoordBuffer.first, texCoordBuffer.second);
 
-    contextGL->setAttribs(tangentBuffer.first, tangentBuffer.second);
-    contextGL->setAttribs(binormalBuffer.first, binormalBuffer.second);
+    contextGL->setAttribs(*tangentBuffer.first, tangentBuffer.second);
+    contextGL->setAttribs(*binormalBuffer.first, binormalBuffer.second);
 
-    contextGL->setIndices(indicesBuffer);
+    contextGL->setIndices(*indicesBuffer);
 
     contextGL->setUniform(viewInverseUniform.second, viewInverseUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(lightWorldPosUniform.second, lightWorldPosUniform.first, GL_FLOAT_VEC3);
@@ -138,16 +138,16 @@ void FishModelGL::prepareForDraw() const
 
     // Fish models includes small, medium and big. Some of them contains reflection and skybox
     // texture, but some doesn't.
-    contextGL->setTexture(diffuseTexture.first, diffuseTexture.second, 0);
-    contextGL->setTexture(normalTexture.first, normalTexture.second, 1);
+    contextGL->setTexture(*diffuseTexture.first, diffuseTexture.second, 0);
+    contextGL->setTexture(*normalTexture.first, normalTexture.second, 1);
     if (skyboxTexture.second != -1 && reflectionTexture.second != -1)
     {
-        contextGL->setTexture(reflectionTexture.first, reflectionTexture.second, 2);
-        contextGL->setTexture(skyboxTexture.first, skyboxTexture.second, 3);
+        contextGL->setTexture(*reflectionTexture.first, reflectionTexture.second, 2);
+        contextGL->setTexture(*skyboxTexture.first, skyboxTexture.second, 3);
     }
 }
 
-void FishModelGL::updatePerInstanceUniforms(WorldUniforms *WorldUniforms)
+void FishModelGL::updatePerInstanceUniforms(const WorldUniforms &WorldUniforms)
 {
     contextGL->setUniform(scaleUniform.second, &scaleUniform.first, GL_FLOAT);
     contextGL->setUniform(timeUniform.second, &timeUniform.first, GL_FLOAT);

--- a/src/aquarium-optimized/opengl/FishModelGL.h
+++ b/src/aquarium-optimized/opengl/FishModelGL.h
@@ -20,7 +20,7 @@ class FishModelGL : public FishModel
   public:
     FishModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
     void prepareForDraw() const override;
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
     void init() override;
     void draw() override;
@@ -71,7 +71,7 @@ class FishModelGL : public FishModel
     std::pair<BufferGL *, int> tangentBuffer;
     std::pair<BufferGL *, int> binormalBuffer;
 
-    BufferGL * indicesBuffer;
+    BufferGL *indicesBuffer;
 
   private:
     const ContextGL *contextGL;

--- a/src/aquarium-optimized/opengl/GenericModelGL.cpp
+++ b/src/aquarium-optimized/opengl/GenericModelGL.cpp
@@ -77,7 +77,7 @@ void GenericModelGL::init()
 
 void GenericModelGL::draw()
 {
-    contextGL->drawElements(indicesBuffer);
+    contextGL->drawElements(*indicesBuffer);
 }
 
 void GenericModelGL::prepareForDraw() const
@@ -88,19 +88,19 @@ void GenericModelGL::prepareForDraw() const
     ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
     contextGL->bindVAO(programGL->getVAOId());
 
-    contextGL->setAttribs(positionBuffer.first, positionBuffer.second);
-    contextGL->setAttribs(normalBuffer.first, normalBuffer.second);
-    contextGL->setAttribs(texCoordBuffer.first, texCoordBuffer.second);
+    contextGL->setAttribs(*positionBuffer.first, positionBuffer.second);
+    contextGL->setAttribs(*normalBuffer.first, normalBuffer.second);
+    contextGL->setAttribs(*texCoordBuffer.first, texCoordBuffer.second);
 
     // diffuseVertexShader doesn't contains tangent and binormal but normalMapVertexShader
     // contains the two buffers.
     if (tangentBuffer.second != -1 && binormalBuffer.second != -1)
     {
-        contextGL->setAttribs(tangentBuffer.first, tangentBuffer.second);
-        contextGL->setAttribs(binormalBuffer.first, binormalBuffer.second);
+        contextGL->setAttribs(*tangentBuffer.first, tangentBuffer.second);
+        contextGL->setAttribs(*binormalBuffer.first, binormalBuffer.second);
     }
 
-    contextGL->setIndices(indicesBuffer);
+    contextGL->setIndices(*indicesBuffer);
 
     contextGL->setUniform(viewInverseUniform.second, viewInverseUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(lightWorldPosUniform.second, lightWorldPosUniform.first, GL_FLOAT_VEC3);
@@ -114,16 +114,16 @@ void GenericModelGL::prepareForDraw() const
     contextGL->setUniform(fogOffsetUniform.second, &fogOffsetUniform.first, GL_FLOAT);
     contextGL->setUniform(fogColorUniform.second, fogColorUniform.first, GL_FLOAT_VEC4);
 
-    contextGL->setTexture(diffuseTexture.first, diffuseTexture.second, 0);
+    contextGL->setTexture(*diffuseTexture.first, diffuseTexture.second, 0);
     // Generic models includes Arch, coral, rock, ship, etc. diffuseFragmentShader doesn't contain
     // normalMap texture but normalMapFragmentShader contains.
     if (normalTexture.second != -1)
     {
-        contextGL->setTexture(normalTexture.first, normalTexture.second, 1);
+        contextGL->setTexture(*normalTexture.first, normalTexture.second, 1);
     }
 }
 
-void GenericModelGL::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void GenericModelGL::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
     contextGL->setUniform(worldUniform.second, worldUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(worldViewProjectionUniform.second, worldViewProjectionUniform.first,

--- a/src/aquarium-optimized/opengl/GenericModelGL.h
+++ b/src/aquarium-optimized/opengl/GenericModelGL.h
@@ -23,7 +23,7 @@ class GenericModelGL : public Model
                    MODELNAME name,
                    bool blend);
     void prepareForDraw() const override;
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void init() override;
     void draw() override;
 
@@ -55,7 +55,7 @@ class GenericModelGL : public Model
     std::pair<BufferGL *, int> tangentBuffer;
     std::pair<BufferGL *, int> binormalBuffer;
 
-    BufferGL * indicesBuffer;
+    BufferGL *indicesBuffer;
 
   private:
     const ContextGL *contextGL;

--- a/src/aquarium-optimized/opengl/InnerModelGL.cpp
+++ b/src/aquarium-optimized/opengl/InnerModelGL.cpp
@@ -82,7 +82,7 @@ void InnerModelGL::init()
 
 void InnerModelGL::draw()
 {
-    contextGL->drawElements(indicesBuffer);
+    contextGL->drawElements(*indicesBuffer);
 }
 
 void InnerModelGL::prepareForDraw() const
@@ -93,14 +93,14 @@ void InnerModelGL::prepareForDraw() const
     ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
     contextGL->bindVAO(programGL->getVAOId());
 
-    contextGL->setAttribs(positionBuffer.first, positionBuffer.second);
-    contextGL->setAttribs(normalBuffer.first, normalBuffer.second);
-    contextGL->setAttribs(texCoordBuffer.first, texCoordBuffer.second);
+    contextGL->setAttribs(*positionBuffer.first, positionBuffer.second);
+    contextGL->setAttribs(*normalBuffer.first, normalBuffer.second);
+    contextGL->setAttribs(*texCoordBuffer.first, texCoordBuffer.second);
 
-    contextGL->setAttribs(tangentBuffer.first, tangentBuffer.second);
-    contextGL->setAttribs(binormalBuffer.first, binormalBuffer.second);
+    contextGL->setAttribs(*tangentBuffer.first, tangentBuffer.second);
+    contextGL->setAttribs(*binormalBuffer.first, binormalBuffer.second);
 
-    contextGL->setIndices(indicesBuffer);
+    contextGL->setIndices(*indicesBuffer);
 
     contextGL->setUniform(viewInverseUniform.second, viewInverseUniform.first, GL_FLOAT_MAT4);
     // lightWorldPosition is optimized away on mesa because it's not used by shader
@@ -113,13 +113,13 @@ void InnerModelGL::prepareForDraw() const
     contextGL->setUniform(tankColorFudgeUniform.second, &tankColorFudgeUniform.first, GL_FLOAT);
     contextGL->setUniform(refractionFudgeUniform.second, &refractionFudgeUniform.first, GL_FLOAT);
 
-    contextGL->setTexture(diffuseTexture.first, diffuseTexture.second, 0);
-    contextGL->setTexture(normalTexture.first, normalTexture.second, 1);
-    contextGL->setTexture(reflectionTexture.first, reflectionTexture.second, 2);
-    contextGL->setTexture(skyboxTexture.first, skyboxTexture.second, 3);
+    contextGL->setTexture(*diffuseTexture.first, diffuseTexture.second, 0);
+    contextGL->setTexture(*normalTexture.first, normalTexture.second, 1);
+    contextGL->setTexture(*reflectionTexture.first, reflectionTexture.second, 2);
+    contextGL->setTexture(*skyboxTexture.first, skyboxTexture.second, 3);
 }
 
-void InnerModelGL::updatePerInstanceUniforms(WorldUniforms* worldUniforms)
+void InnerModelGL::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
     contextGL->setUniform(worldUniform.second, worldUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(worldViewProjectionUniform.second, worldViewProjectionUniform.first,

--- a/src/aquarium-optimized/opengl/InnerModelGL.h
+++ b/src/aquarium-optimized/opengl/InnerModelGL.h
@@ -19,7 +19,7 @@ class InnerModelGL : public Model
   public:
     InnerModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
     void prepareForDraw() const override;
-    void updatePerInstanceUniforms(WorldUniforms *WorldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &WorldUniforms) override;
     void init() override;
     void draw() override;
 
@@ -52,7 +52,7 @@ class InnerModelGL : public Model
     std::pair<BufferGL *, int> tangentBuffer;
     std::pair<BufferGL *, int> binormalBuffer;
 
-    BufferGL * indicesBuffer;
+    BufferGL *indicesBuffer;
 
   private:
     const ContextGL *contextGL;

--- a/src/aquarium-optimized/opengl/OutsideModelGL.cpp
+++ b/src/aquarium-optimized/opengl/OutsideModelGL.cpp
@@ -71,7 +71,7 @@ void OutsideModelGL::init()
 
 void OutsideModelGL::draw()
 {
-    contextGL->drawElements(indicesBuffer);
+    contextGL->drawElements(*indicesBuffer);
 }
 
 void OutsideModelGL::prepareForDraw() const
@@ -82,11 +82,11 @@ void OutsideModelGL::prepareForDraw() const
     ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
     contextGL->bindVAO(programGL->getVAOId());
 
-    contextGL->setAttribs(positionBuffer.first, positionBuffer.second);
-    contextGL->setAttribs(normalBuffer.first, normalBuffer.second);
-    contextGL->setAttribs(texCoordBuffer.first, texCoordBuffer.second);
+    contextGL->setAttribs(*positionBuffer.first, positionBuffer.second);
+    contextGL->setAttribs(*normalBuffer.first, normalBuffer.second);
+    contextGL->setAttribs(*texCoordBuffer.first, texCoordBuffer.second);
 
-    contextGL->setIndices(indicesBuffer);
+    contextGL->setIndices(*indicesBuffer);
 
     contextGL->setUniform(viewInverseUniform.second, viewInverseUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(lightWorldPosUniform.second, lightWorldPosUniform.first, GL_FLOAT_VEC3);
@@ -100,10 +100,10 @@ void OutsideModelGL::prepareForDraw() const
     contextGL->setUniform(fogOffsetUniform.second, &fogOffsetUniform.first, GL_FLOAT);
     contextGL->setUniform(fogColorUniform.second, fogColorUniform.first, GL_FLOAT_VEC4);
 
-    contextGL->setTexture(diffuseTexture.first, diffuseTexture.second, 0);
+    contextGL->setTexture(*diffuseTexture.first, diffuseTexture.second, 0);
 }
 
-void OutsideModelGL::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void OutsideModelGL::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
     contextGL->setUniform(worldUniform.second, worldUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(worldViewProjectionUniform.second, worldViewProjectionUniform.first,

--- a/src/aquarium-optimized/opengl/OutsideModelGL.h
+++ b/src/aquarium-optimized/opengl/OutsideModelGL.h
@@ -23,7 +23,7 @@ class OutsideModelGL : public Model
                    MODELNAME name,
                    bool blend);
     void prepareForDraw() const override;
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void init() override;
     void draw() override;
 
@@ -51,7 +51,7 @@ class OutsideModelGL : public Model
     std::pair<BufferGL *, int> normalBuffer;
     std::pair<BufferGL *, int> texCoordBuffer;
 
-    BufferGL * indicesBuffer;
+    BufferGL *indicesBuffer;
 
   private:
     const ContextGL *contextGL;

--- a/src/aquarium-optimized/opengl/ProgramGL.cpp
+++ b/src/aquarium-optimized/opengl/ProgramGL.cpp
@@ -38,14 +38,14 @@ ProgramGL::ProgramGL(ContextGL *context, std::string vId, std::string fId)
     mProgramId(0u),
     context(context)
 {
-    context->generateProgram(&mProgramId);
-    context->generateVAO(&mVAO);
+    mProgramId= context->generateProgram();
+    mVAO = context->generateVAO();
 }
 
 ProgramGL::~ProgramGL()
 {
-    context->deleteVAO(&mVAO);
-    context->deleteProgram(&mProgramId);
+    context->deleteVAO(mVAO);
+    context->deleteProgram(mProgramId);
 }
 
 void ProgramGL::loadProgram()

--- a/src/aquarium-optimized/opengl/SeaweedModelGL.cpp
+++ b/src/aquarium-optimized/opengl/SeaweedModelGL.cpp
@@ -70,7 +70,7 @@ void SeaweedModelGL::init()
 
 void SeaweedModelGL::draw()
 {
-    contextGL->drawElements(indicesBuffer);
+    contextGL->drawElements(*indicesBuffer);
 }
 
 void SeaweedModelGL::prepareForDraw() const
@@ -81,11 +81,11 @@ void SeaweedModelGL::prepareForDraw() const
     ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
     contextGL->bindVAO(programGL->getVAOId());
 
-    contextGL->setAttribs(positionBuffer.first, positionBuffer.second);
-    contextGL->setAttribs(normalBuffer.first, normalBuffer.second);
-    contextGL->setAttribs(texCoordBuffer.first, texCoordBuffer.second);
+    contextGL->setAttribs(*positionBuffer.first, positionBuffer.second);
+    contextGL->setAttribs(*normalBuffer.first, normalBuffer.second);
+    contextGL->setAttribs(*texCoordBuffer.first, texCoordBuffer.second);
 
-    contextGL->setIndices(indicesBuffer);
+    contextGL->setIndices(*indicesBuffer);
 
     contextGL->setUniform(viewInverseUniform.second, viewInverseUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(lightWorldPosUniform.second, lightWorldPosUniform.first, GL_FLOAT_VEC3);
@@ -100,10 +100,10 @@ void SeaweedModelGL::prepareForDraw() const
     contextGL->setUniform(fogColorUniform.second, fogColorUniform.first, GL_FLOAT_VEC4);
     contextGL->setUniform(viewProjectionUniform.second, viewProjectionUniform.first, GL_FLOAT_MAT4);
 
-    contextGL->setTexture(diffuseTexture.first, diffuseTexture.second, 0);
+    contextGL->setTexture(*diffuseTexture.first, diffuseTexture.second, 0);
 }
 
-void SeaweedModelGL::updatePerInstanceUniforms(WorldUniforms *worldUniforms)
+void SeaweedModelGL::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
     contextGL->setUniform(worldUniform.second, worldUniform.first, GL_FLOAT_MAT4);
     contextGL->setUniform(timeUniform.second, &timeUniform.first, GL_FLOAT);

--- a/src/aquarium-optimized/opengl/SeaweedModelGL.h
+++ b/src/aquarium-optimized/opengl/SeaweedModelGL.h
@@ -23,7 +23,7 @@ class SeaweedModelGL : public SeaweedModel
                    MODELNAME name,
                    bool blend);
     void prepareForDraw() const override;
-    void updatePerInstanceUniforms(WorldUniforms *worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void init() override;
     void draw() override;
 
@@ -54,7 +54,7 @@ class SeaweedModelGL : public SeaweedModel
     std::pair<BufferGL *, int> normalBuffer;
     std::pair<BufferGL *, int> texCoordBuffer;
 
-    BufferGL * indicesBuffer;
+    BufferGL *indicesBuffer;
 
   private:
     const ContextGL *contextGL;

--- a/src/aquarium-optimized/opengl/TextureGL.cpp
+++ b/src/aquarium-optimized/opengl/TextureGL.cpp
@@ -16,7 +16,7 @@ TextureGL::TextureGL(ContextGL *context, std::string name, std::string url)
     mFormat(GL_RGBA),
     context(context)
 {
-    context->generateTexture(&mTextureId);
+    mTextureId = context->generateTexture();
 }
 
 // initializs cube map
@@ -24,7 +24,7 @@ TextureGL::TextureGL(ContextGL *context, std::string name, const std::vector<std
     : Texture(name, urls, false), mTarget(GL_TEXTURE_CUBE_MAP), mFormat(GL_RGBA), context(context)
 {
     ASSERT(urls.size() == 6);
-    context->generateTexture(&mTextureId);
+    mTextureId = context->generateTexture();
 }
 
 void TextureGL::loadTexture()
@@ -70,5 +70,5 @@ void TextureGL::loadTexture()
 
 TextureGL::~TextureGL()
 {
-    context->deleteTexture(&mTextureId);
+    context->deleteTexture(mTextureId);
 }


### PR DESCRIPTION
This patch does more code clean-ups.
1. Move degToRad() to Matrix.h in aquarium-optimized
2. Don't use a pointer to a basic type as the parameter of any function
3. Always use const& to pass immutable parameters and pointer to pass
mutable parameters