### PR TITLE
Fix quit crash after implementing Imgui

### DIFF
--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -21,10 +21,8 @@ class Program;
 class Model;
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
-const std::string slash = "\\";
 #define M_PI 3.141592653589793
 #else
-const std::string slash = "/";
 #include "math.h"
 #endif
 

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -39,6 +39,7 @@
 
 ContextDawn::ContextDawn(BACKENDTYPE backendType)
     : queue(nullptr),
+      mDevice(nullptr),
       mWindow(nullptr),
       mInstance(),
       mSwapchain(nullptr),
@@ -51,7 +52,6 @@ ContextDawn::ContextDawn(BACKENDTYPE backendType)
       mPipeline(nullptr),
       mBindGroup(nullptr),
       mPreferredSwapChainFormat(dawn::TextureFormat::RGBA8Unorm),
-      mDevice(nullptr),
       mEnableMSAA(false)
 {
     mResourceHelper = new ResourceHelper("dawn", "");
@@ -217,6 +217,7 @@ bool ContextDawn::initialize(
 
     mSceneDepthStencilView = createDepthStencilView();
 
+#ifdef WIN32
     // Setup Dear ImGui context
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
@@ -230,6 +231,7 @@ bool ContextDawn::initialize(
     // imgui_impl_dawn.cpp and imgui_impl_dawn.h
     ImGui_ImplGlfw_InitForOpenGL(mWindow, true);
     ImGui_ImplDawn_Init(this, mPreferredSwapChainFormat, mEnableMSAA);
+#endif
 
     return true;
 }
@@ -579,9 +581,8 @@ void ContextDawn::showFPS(const FPSTimer &fpsTimer)
 {
     // TODO(yizhou): Dawn doesn't support recreating swap chain if framebuffer size is changed. This will cause 
     // 'AcquireNextImage' returns an error code on linux vulkan backend. The error is 'VK_ERROR_OUT_OF_DATE_KHR'.
-#ifdef __linux__
-    if (mBackendType == "Dawn Vulkan")
-        return;
+#ifndef WIN32
+    return;
 #endif
 
     // Start the Dear ImGui frame

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -97,6 +97,8 @@ class ContextDawn : public Context
     dawn::BindGroupLayout groupLayoutWorld;
     dawn::BindGroup bindGroupWorld;
 
+    dawn::Device mDevice;
+
   private:
     bool GetHardwareAdapter(
         std::unique_ptr<dawn_native::Instance> &instance,
@@ -123,8 +125,6 @@ class ContextDawn : public Context
     dawn::Buffer mLightWorldPositionBuffer;
     dawn::Buffer mLightBuffer;
     dawn::Buffer mFogBuffer;
-
-    dawn::Device mDevice;
 
     bool mEnableMSAA;
     std::string mRenderer;


### PR DESCRIPTION
Imgui destory resource error in dawn when exit Aquarium on Windows.
Dawn::device can only create one reference. This might be a bug of Dawn.

@Jiawei-Shao @shaoboyan @qjia7