### PR TITLE
Enlarge Imgui buffer size

### DIFF
--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
@@ -28,8 +28,8 @@ ContextDawn *mContextDawn(nullptr);
 int mIndexBufferSize  = 0;
 int mVertexBufferSize = 0;
 bool mEnableMSAA      = false;
-ImDrawVert mVertexData[5000];
-ImDrawIdx mIndexData[5000];
+ImDrawVert mVertexData[40000];
+ImDrawIdx mIndexData[10000];
 
 struct VERTEX_CONSTANT_BUFFER
 {


### PR DESCRIPTION
Imgui buffer size is not big enough, which leads to app crash when exit.